### PR TITLE
optimize mentor dashboard metrics and count logic

### DIFF
--- a/src/app/[admin]/mentorsDashboard/dashboard/page.tsx
+++ b/src/app/[admin]/mentorsDashboard/dashboard/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react"
 import { useMyMentorSlots } from "@/hooks/useMyMentorSlots"
 import { useMyMentorSessions, type MyMentorSession } from "@/hooks/useMyMentorSessions"
+import { useMentorMetrics } from "@/hooks/useMentorMetrics"
 import { useNotifications } from "@/hooks/useNotifications"
 import { Progress } from "@nextui-org/react"
 import { cn } from "@/lib/utils"
@@ -184,7 +185,12 @@ export default function DashboardPage() {
     sessions: completedSessions,
     loading: completedSessionsLoading,
     error: completedSessionsError,
-  } = useMyMentorSessions(true, "/mentor-sessions/mentor/my", "completed")
+  } = useMyMentorSessions(true, "/mentor-sessions/mentor/my", "completed", "desc")
+  const {
+    metrics,
+    loading: metricsLoading,
+    error: metricsError,
+  } = useMentorMetrics(true)
   const {
     notifications: apiNotifications,
     loading: notificationsLoading,
@@ -213,8 +219,8 @@ export default function DashboardPage() {
     [slots]
   )
 
-  const sessionsDataLoading = sessionsLoading || completedSessionsLoading
-  const sessionsDataError = sessionsError || completedSessionsError
+  const sessionsDataLoading = sessionsLoading || completedSessionsLoading || metricsLoading
+  const sessionsDataError = sessionsError || completedSessionsError || metricsError
 
   const recentCompletedSessions = useMemo(
     () =>
@@ -230,12 +236,6 @@ export default function DashboardPage() {
             "createdAt",
           ]),
         }))
-        .sort((left, right) => {
-          const leftTime = getDateValue(left.eventTime)?.getTime() || 0
-          const rightTime = getDateValue(right.eventTime)?.getTime() || 0
-
-          return rightTime - leftTime
-        })
         .slice(0, 4),
     [completedSessions]
   )
@@ -245,36 +245,16 @@ export default function DashboardPage() {
     [slots]
   )
 
-  const completionRate =
-    sessions.length === 0
-      ? 0
-      : Math.round((completedSessions.length / sessions.length) * 100)
+  const completionRate = (() => {
+    const totalCount = Number(metrics?.sessions.total) || 0
+    const completedCount = Number(metrics?.sessions.completed) || 0
+    return totalCount === 0 ? 0 : Math.round((completedCount / totalCount) * 100)
+  })()
 
   const totalHoursScheduled = useMemo(
     () => slots.reduce((sum, slot) => sum + slot.durationMinutes, 0) / 60,
     [slots]
   )
-
-  const ratedCompletedSessions = useMemo(
-    () => completedSessions.filter((session) => typeof session.mentorRating === "number"),
-    [completedSessions]
-  )
-
-  const averageRatingValue = useMemo(() => {
-    if (ratedCompletedSessions.length === 0) {
-      return null
-    }
-
-    const totalRating = ratedCompletedSessions.reduce(
-      (sum, session) => sum + (session.mentorRating || 0),
-      0
-    )
-
-    return totalRating / ratedCompletedSessions.length
-  }, [ratedCompletedSessions])
-
-  const averageRatingDisplay = averageRatingValue === null ? "—" : averageRatingValue.toFixed(1)
-  const averageRatingRounded = averageRatingValue === null ? 0 : Math.round(averageRatingValue)
 
   const slotDurationById = useMemo(() => {
     const durationById = new Map<number, number>()
@@ -363,9 +343,9 @@ export default function DashboardPage() {
                   <CheckCircle className="w-5 h-5 text-muted-foreground" />
               </div>
             <div className="text-left">
-              <p className="text-2xl font-bold">{completedSessions.length}</p>
+              <p className="text-2xl font-bold">{Number(metrics?.sessions.completed) || 0}</p>
               <p className="text-sm text-muted-foreground">Completed Sessions</p>
-              <p className="text-sm  mt-4">of {sessions.length} total bookings</p>
+              <p className="text-sm  mt-4">of {Number(metrics?.sessions.total) || 0} total bookings</p>
             </div>
               </div>
               <div className="flex flex-col items-end gap-2">
@@ -381,7 +361,7 @@ export default function DashboardPage() {
               </div>
 
             <div className="text-left">
-              <p className="text-2xl font-bold">{sessions.length}</p>
+              <p className="text-2xl font-bold">{Number(metrics?.sessions.total) || 0}</p>
               <p className="text-sm text-muted-foreground">Bookings Managed</p>
               <p className="text-sm  mt-4">all lifecycle states</p>
             </div>
@@ -399,11 +379,11 @@ export default function DashboardPage() {
                   <Star className="w-5 h-5 text-muted-foreground" />
               </div>
             <div className="text-left">
-              <p className="text-2xl font-bold">{averageRatingDisplay}</p>
+              <p className="text-2xl font-bold">{metrics?.ratings.averageRating ? Number(metrics.ratings.averageRating).toFixed(1) : "—"}</p>
               <p className="text-sm text-muted-foreground">Avg Rating</p>
               <p className="text-sm  mt-4">
-                {ratedCompletedSessions.length > 0
-                  ? `From ${ratedCompletedSessions.length} rated sessions`
+                {metrics?.ratings.totalRatings && Number(metrics.ratings.totalRatings) > 0
+                  ? `From ${metrics.ratings.totalRatings} rated sessions`
                   : "No ratings yet"}
               </p>
             </div>
@@ -457,7 +437,7 @@ export default function DashboardPage() {
             <CardHeader className="flex flex-row items-start justify-between gap-3">
               <div className="space-y-0.5 text-left">
                 <CardTitle className="text-sm font-bold text-text-primary">Recent Sessions</CardTitle>
-                <p className="text-xs text-text-muted">{completedSessions.length} completed</p>
+                <p className="text-xs text-text-muted">{Number(metrics?.sessions.completed) || 0} completed</p>
               </div>
               <Button asChild variant="link" size="sm" className="text-emerald-700 text-xs font-semibold p-0 h-autod">
                 <Link href={`/${role}/mentorsDashboard/sessions`}>
@@ -532,14 +512,14 @@ export default function DashboardPage() {
                    <Star className="w-3.5 h-3.5 text-emerald-600" />
                    <span className="text-xs font-semibold text-slate-600">Avg Rating</span>
                 </div>
-                <p className="text-2xl font-bold mb-2">{averageRatingDisplay}</p>
+                <p className="text-2xl font-bold mb-2">{metrics?.ratings.averageRating ? Number(metrics.ratings.averageRating).toFixed(1) : "—"}</p>
                 <div className="flex gap-0.5">
                   {[...Array(5)].map((_, i) => (
                     <Star
                       key={i}
                       className={cn(
                         "w-3 h-3",
-                        i < averageRatingRounded
+                        metrics?.ratings.averageRating && i < Math.round(Number(metrics.ratings.averageRating))
                           ? "fill-emerald-500 text-emerald-500"
                           : "fill-transparent text-emerald-200"
                       )}
@@ -553,7 +533,7 @@ export default function DashboardPage() {
                       <p className="text-xs font-medium text-text-secondary">Hours Delivered</p>
                     </div>
                     <p className="text-2xl font-bold text-text-primary tabular-nums">{hoursDelivered}h</p>
-                    <p className="text-[10px] text-text-muted mt-1">Across {completedSessions.length} sessions</p>
+                    <p className="text-[10px] text-text-muted mt-1">Across {Number(metrics?.sessions.completed) || 0} sessions</p>
                 </div>
                <div className="bg-slate-50/50 rounded-xl p-4 border">
                 <div className="flex items-center gap-1.5 mb-2">

--- a/src/app/[admin]/mentorsDashboard/performance/page.tsx
+++ b/src/app/[admin]/mentorsDashboard/performance/page.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Star } from "lucide-react"
 import { useMyMentorSessions } from "@/hooks/useMyMentorSessions"
+import { useMentorMetrics } from "@/hooks/useMentorMetrics"
 
 const formatDateTime = (value?: string | null) => {
   if (!value) return "—"
@@ -81,7 +82,7 @@ export default function PerformanceMetrics() {
     sessions: completedSessions,
     loading: completedSessionsLoading,
     error: completedSessionsError,
-  } = useMyMentorSessions(true, "/mentor-sessions/mentor/my", "completed")
+  } = useMyMentorSessions(true, "/mentor-sessions/mentor/my", "completed", "desc")
 
   const {
     sessions: upcomingSlots,
@@ -89,10 +90,17 @@ export default function PerformanceMetrics() {
     error: upcomingSessionsError,
   } = useMyMentorSessions(true, "/mentor-sessions/mentor/my", "upcoming")
 
-  const completionRate =
-    allSessions.length === 0
-      ? 0
-      : Math.round((completedSessions.length / allSessions.length) * 100)
+  const {
+    metrics,
+    loading: metricsLoading,
+    error: metricsError,
+  } = useMentorMetrics(true)
+
+  const completionRate = (() => {
+    const totalCount = Number(metrics?.sessions.total) || 0
+    const completedCount = Number(metrics?.sessions.completed) || 0
+    return totalCount === 0 ? 0 : Math.round((completedCount / totalCount) * 100)
+  })()
 
   const totalScheduledMinutes = useMemo(
     () =>
@@ -104,51 +112,37 @@ export default function PerformanceMetrics() {
     [allSessions]
   )
 
-  const averageSessionLength =
-    allSessions.length === 0 ? 0 : Math.round(totalScheduledMinutes / allSessions.length)
+  const averageSessionLength = (() => {
+    const totalCount = Number(metrics?.sessions.total) || 0
+    return totalCount === 0 ? 0 : Math.round(totalScheduledMinutes / totalCount)
+  })()
 
   const totalScheduledHours = totalScheduledMinutes / 60
 
-  const recentCompleted = useMemo(
-    () =>
-      [...completedSessions]
-        .sort((a, b) => {
-          const aTime = new Date(a.completedAt || a.slotEnd || a.slotStart || 0).getTime()
-          const bTime = new Date(b.completedAt || b.slotEnd || b.slotStart || 0).getTime()
-
-          return bTime - aTime
-        }),
-    [completedSessions]
-  )
+  const recentCompleted = completedSessions
 
   const averageRating = useMemo(() => {
-    const ratedSessions = completedSessions.filter(
-      (session) => typeof session.mentorRating === "number"
-    )
-
-    if (ratedSessions.length === 0) return null
-
-    const total = ratedSessions.reduce((sum, session) => sum + (session.mentorRating || 0), 0)
-
-    return (total / ratedSessions.length).toFixed(1)
-  }, [completedSessions])
+    if (!metrics?.ratings.averageRating) return null
+    return Number(metrics.ratings.averageRating).toFixed(1)
+  }, [metrics?.ratings.averageRating])
 
   const sessionMix = useMemo(() => {
-    const cancelled = allSessions.filter(
-      (session) => session.sessionLifecycleState === "CANCELLED"
-    ).length
-
-    const reschedulePending = allSessions.filter(
-      (session) => session.sessionLifecycleState === "RESCHEDULE_PENDING"
+    const completedCount = Number(metrics?.sessions.completed) || 0
+    const cancelledCount = Number(metrics?.sessions.cancelled) || 0
+    const upcomingCount = Number(metrics?.upcomingSessions) || 0
+    
+    // Calculate reschedule count from all sessions by filtering for status
+    const rescheduleCount = allSessions.filter(
+      session => session.status?.toLowerCase() === "rescheduled"
     ).length
 
     return [
-      { label: "Completed", value: completedSessions.length, barClass: "bg-green-600" },
-      { label: "Upcoming", value: upcomingSlots.length, barClass: "bg-emerald-400" },
-      { label: "Cancelled", value: cancelled, barClass: "bg-gray-400" },
-      { label: "Reschedule", value: reschedulePending, barClass: "bg-orange-400" },
+      { label: "Completed", value: completedCount, barClass: "bg-green-600" },
+      { label: "Upcoming", value: upcomingCount, barClass: "bg-emerald-400" },
+      { label: "Cancelled", value: cancelledCount, barClass: "bg-gray-400" },
+      { label: "Reschedule", value: rescheduleCount, barClass: "bg-orange-400" },
     ]
-  }, [allSessions, completedSessions.length, upcomingSlots.length])
+  }, [metrics?.sessions.cancelled, metrics?.sessions.completed, metrics?.upcomingSessions, allSessions])
 
   const maxSessionMixValue = useMemo(
     () => Math.max(1, ...sessionMix.map((item) => item.value)),
@@ -170,7 +164,7 @@ export default function PerformanceMetrics() {
             <p className="text-2xl font-semibold">{completionRate}%</p>
             <p className="text-sm font-medium">Completion Rate</p>
             <p className="text-xs text-muted-foreground">
-              {completedSessions.length} of {allSessions.length} sessions completed
+              {Number(metrics?.sessions.completed) || 0} of {Number(metrics?.sessions.total) || 0} sessions completed
             </p>
           </CardContent>
         </Card>
@@ -191,13 +185,13 @@ export default function PerformanceMetrics() {
           <CardContent className="p-5 text-left">
             <p className="text-2xl font-semibold">{totalScheduledHours.toFixed(1)}h</p>
             <p className="text-sm font-medium">Scheduled Hours</p>
-            <p className="text-xs text-muted-foreground">Across {allSessions.length} sessions</p>
+            <p className="text-xs text-muted-foreground">Across {Number(metrics?.sessions.total) || 0} sessions</p>
           </CardContent>
         </Card>
 
         <Card className='rounded-3xl'>
           <CardContent className="p-5 text-left">
-            <p className="text-2xl font-semibold">{upcomingSlots.length}</p>
+            <p className="text-2xl font-semibold">{Number(metrics?.upcomingSessions) || 0}</p>
             <p className="text-sm font-medium">Upcoming Slots</p>
             <p className="text-xs text-muted-foreground">Booked + open upcoming schedule</p>
           </CardContent>
@@ -213,12 +207,12 @@ export default function PerformanceMetrics() {
           <CardContent>
             <div className="grid grid-cols-3 gap-3">
               <div className="bg-gray-100 rounded-3xl p-3 text-center">
-                <p className="font-semibold">{allSessions.length}</p>
+                <p className="font-semibold">{Number(metrics?.sessions.total) || 0}</p>
                 <p className="text-xs text-muted-foreground">Total</p>
               </div>
 
               <div className="bg-gray-100 rounded-3xl p-3 text-center">
-                <p className="font-semibold">{completedSessions.length}</p>
+                <p className="font-semibold">{Number(metrics?.sessions.completed) || 0}</p>
                 <p className="text-xs text-muted-foreground">Completed</p>
               </div>
 
@@ -259,7 +253,7 @@ export default function PerformanceMetrics() {
               {!upcomingSessionsLoading && upcomingSessionsError && (
                 <p className="text-xs text-red-500">{upcomingSessionsError}</p>
               )}
-              {!allSessionsLoading && !allSessionsError && allSessions.length === 0 && (
+              {!allSessionsLoading && !allSessionsError && (Number(metrics?.sessions.total) || 0) === 0 && (
                 <p className="text-xs text-muted-foreground">No sessions yet.</p>
               )}
             </div>
@@ -311,7 +305,7 @@ export default function PerformanceMetrics() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
         <Card className='rounded-3xl'>
           <CardContent className="p-5 text-left">
-            <p className="text-xl font-semibold">{upcomingSlots.length}</p>
+            <p className="text-xl font-semibold">{Number(metrics?.upcomingSessions) || 0}</p>
             <p className="text-sm font-medium">Upcoming Slots</p>
             <p className="text-xs text-muted-foreground">Current future availability</p>
           </CardContent>
@@ -327,15 +321,18 @@ export default function PerformanceMetrics() {
 
         <Card className='rounded-3xl'>
           <CardContent className="p-5 text-left">
-            <p className="text-xl font-semibold">{allSessions.length}</p>
+            <p className="text-xl font-semibold">{Number(metrics?.sessions.total) || 0}</p>
             <p className="text-sm font-medium">Total Sessions</p>
             <p className="text-xs text-muted-foreground">
-              {(allSessionsLoading || completedSessionsLoading || upcomingSessionsLoading)
+              {(allSessionsLoading || completedSessionsLoading || upcomingSessionsLoading || metricsLoading)
                 ? "Loading..."
-                : "Fetched from /mentor-sessions/mentor/my"}
+                : "Fetched from /mentor-slots/metrics/me"}
             </p>
             {!allSessionsLoading && allSessionsError && (
               <p className="text-xs text-red-500 mt-1">{allSessionsError}</p>
+            )}
+            {!metricsLoading && metricsError && (
+              <p className="text-xs text-red-500 mt-1">{metricsError}</p>
             )}
           </CardContent>
         </Card>

--- a/src/app/[admin]/mentorsDashboard/sessions/page.tsx
+++ b/src/app/[admin]/mentorsDashboard/sessions/page.tsx
@@ -109,6 +109,11 @@ export default function SessionsPage() {
     Record<number, true>
   >({})
 
+  const { counts: summaryCounts } = useMyMentorSessions(
+    true,
+    "/mentor-sessions/mentor/my"
+  )
+
   const {
     sessions: apiSessions,
     loading,
@@ -428,7 +433,7 @@ export default function SessionsPage() {
             >
               All
               <span className="bg-green-600 text-white text-xs px-1.5 py-0.5 rounded-full">
-                {apiSessions.length}
+                {Number(summaryCounts.total) || 0}
               </span>
             </button>
 
@@ -437,12 +442,15 @@ export default function SessionsPage() {
                 setActiveTab("upcoming")
                 setSelectedBookingId(null)
               }}
-              className={`px-3 py-2 text-sm border-b-2 rounded-t-lg ${activeTab === "upcoming"
+              className={`flex items-center gap-2 px-3 py-2 text-sm border-b-2 rounded-t-lg ${activeTab === "upcoming"
                   ? "border-green-600 bg-green-50 font-semibold"
                   : "border-transparent text-muted-foreground"
                 }`}
             >
               Upcoming
+              <span className="bg-blue-600 text-white text-xs px-1.5 py-0.5 rounded-full">
+                {Number(summaryCounts.upcoming) || 0}
+              </span>
             </button>
 
             <button
@@ -450,12 +458,15 @@ export default function SessionsPage() {
                 setActiveTab("reschedule")
                 setSelectedBookingId(null)
               }}
-              className={`px-3 py-2 text-sm border-b-2 rounded-t-lg ${activeTab === "reschedule"
+              className={`flex items-center gap-2 px-3 py-2 text-sm border-b-2 rounded-t-lg ${activeTab === "reschedule"
                   ? "border-green-600 bg-green-50 font-semibold"
                   : "border-transparent text-muted-foreground"
                 }`}
             >
               Reschedule Requests
+              <span className="bg-orange-600 text-white text-xs px-1.5 py-0.5 rounded-full">
+                {Number(summaryCounts.reschedule) || 0}
+              </span>
             </button>
 
             <button
@@ -463,12 +474,15 @@ export default function SessionsPage() {
                 setActiveTab("completed")
                 setSelectedBookingId(null)
               }}
-              className={`px-3 py-2 text-sm border-b-2 rounded-t-lg ${activeTab === "completed"
+              className={`flex items-center gap-2 px-3 py-2 text-sm border-b-2 rounded-t-lg ${activeTab === "completed"
                   ? "border-green-600 bg-green-50 font-semibold"
                   : "border-transparent text-muted-foreground"
                 }`}
             >
               Completed
+              <span className="bg-purple-600 text-white text-xs px-1.5 py-0.5 rounded-full">
+                {Number(summaryCounts.completed) || 0}
+              </span>
             </button>
           </div>
 

--- a/src/app/student/_pages/CourseDashboardPage.tsx
+++ b/src/app/student/_pages/CourseDashboardPage.tsx
@@ -777,7 +777,7 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
         <div className="w-full rounded-b-lg shadow-8dp bg-gradient-to-br from-primary/8 via-background to-accent/8  border-border/50">
           <div className="max-w-7xl mx-auto p-6 md:p-8">
             {/* Desktop Layout */}
-            <div className="hidden border md:flex flex-col md:flex-row items-start gap-6 mb-6 rounded-3xl bg-white p-6 border shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300">
+            <div className="hidden border md:flex flex-col md:flex-row items-start gap-6 mb-6 rounded-lg bg-white p-6 border shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300">
 
               <div className="flex-shrink-0">
                 <Image
@@ -850,7 +850,7 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
             </div>
 
             {/* Progress Bar - Updated with primary-light background */}
-            <div className="mb-6  rounded-3xl bg-white p-6 border shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300">
+            <div className="mb-6  rounded-lg bg-white p-6 border shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300">
               <div className=" mb-6">
                 {/* <div className="relative bg-primary-light rounded-full h-2 w-full"> */}
                 {/* <div
@@ -931,7 +931,7 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
                     const upcomingChapterId = latestCourseData?.newChapter?.id || 1;
 
                     return (
-                      <Card key={module.id} className={`rounded-3xl border p-0 transition-all duration-300 my-4   ${isCurrentModule ? 'border-2 border-primary my-4' : 'my-4'} ${isLocked ? 'opacity-60' : ''} ${!isLocked ? 'cursor-pointer hover:shadow-8dp transition-shadow' : 'cursor-not-allowed'}`}>
+                      <Card key={module.id} className={`rounded-lg border p-0 transition-all duration-300 my-4   ${isCurrentModule ? 'border-2 border-primary my-4' : 'my-4'} ${isLocked ? 'opacity-60' : ''} ${!isLocked ? 'cursor-pointer hover:shadow-8dp transition-shadow' : 'cursor-not-allowed'}`}>
                         <CardContent className={`p-6 ${isLocked ? ' cursor-not-allowed' : ''}`}>
                           <div className="flex flex-col lg:flex-row lg:justify-between lg:items-start gap-4">
                             <div className="flex-1 text-left">
@@ -1088,7 +1088,7 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
             {/* Right Column - What's Next & Attendance */}
             <div className="space-y-8">
               {/* What's Next Section */}
-              <Card className="shadow-4dp text-left rounded-3xl bg-white border shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300">
+              <Card className="shadow-4dp text-left rounded-lg bg-white border shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300">
                 <CardHeader className="pb-4">
                   <CardTitle className="text-lg font-semibold">What&apos;s Next?</CardTitle>
                   {/* <p className="text-sm text-muted-foreground">
@@ -1196,7 +1196,7 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
               </Card>
 
               {/* Attendance */}
-              <Card className=" text-left rounded-3xl border shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300">
+              <Card className=" text-left rounded-lg border shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300">
                 <CardHeader className="pb-4">
                   <CardTitle className="text-xl">Attendance</CardTitle>
                 </CardHeader>
@@ -1425,7 +1425,7 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
                   )}
                 </CardContent>
               </Card>
-              <div className="rounded-3xl border border-border bg-card p-5 space-y-1 text-left">
+              <div className="rounded-lg border border-border bg-card p-5 space-y-1 text-left">
                 <p className="text-sm font-bold text-text-primary mb-3">Browse all</p>
                 {QUICK_ACTIONS.map((a) => (
                   <Link

--- a/src/app/student/mentors/[id]/book/page.tsx
+++ b/src/app/student/mentors/[id]/book/page.tsx
@@ -248,7 +248,6 @@ export default function BookSessionPage() {
               <div className="mt-3 text-left text-xs p-3 rounded-lg bg-green-50 text-green-700 border border-green-100">
                 <p className="font-semibold">Booking confirmed</p>
                 <p>Status: {booking.status}</p>
-                <p>Session state: {booking.sessionLifecycleState}</p>
               </div>
             )}
 

--- a/src/app/student/sessions/page.tsx
+++ b/src/app/student/sessions/page.tsx
@@ -88,28 +88,28 @@ export default function MySessions() {
     activeTab as SessionFilter
   )
 
-  const { sessions: upcomingSessionsForCount } = useMyMentorSessions(
+  const { counts: upcomingCounts } = useMyMentorSessions(
     true,
     "/mentor-sessions/my",
     "upcoming"
   )
 
-  const { sessions: completedSessionsForCount } = useMyMentorSessions(
+  const { counts: completedCounts } = useMyMentorSessions(
     true,
     "/mentor-sessions/my",
     "completed"
   )
 
-  const { sessions: cancelledSessionsForCount } = useMyMentorSessions(
+  const { counts: cancelledCounts } = useMyMentorSessions(
     true,
     "/mentor-sessions/my",
     "cancelled"
   )
 
   const counts = {
-    upcoming: upcomingSessionsForCount.length,
-    completed: completedSessionsForCount.length,
-    cancelled: cancelledSessionsForCount.length,
+    upcoming: Number(upcomingCounts.upcoming) || 0,
+    completed: Number(completedCounts.completed) || 0,
+    cancelled: Number(cancelledCounts.cancelled) || 0,
   }
 
   const totalSessions = counts.upcoming + counts.completed + counts.cancelled

--- a/src/hooks/useMentorMetrics.ts
+++ b/src/hooks/useMentorMetrics.ts
@@ -1,0 +1,71 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { api } from '@/utils/axios.config'
+
+export interface SessionMetrics {
+    total: string | number
+    completed: string | number
+    cancelled: string | number
+    missed: string | number
+    completionRate: string | number
+    cancellationRate: string | number
+}
+
+export interface RatingMetrics {
+    averageRating: string | number
+    totalRatings: string | number
+}
+
+export interface UtilizationMetrics {
+    totalSlots: string | number
+    usedSlots: string | number
+    utilizationRate: string | number
+}
+
+export interface MentorMetrics {
+    sessions: SessionMetrics
+    ratings: RatingMetrics
+    upcomingSessions: string | number
+    utilization: UtilizationMetrics
+}
+
+const getErrorMessage = (error: unknown): string => {
+    const message = (error as { response?: { data?: { message?: string } } })
+        ?.response?.data?.message
+
+    return message || 'Failed to fetch mentor metrics'
+}
+
+export function useMentorMetrics(initialFetch = true) {
+    const [metrics, setMetrics] = useState<MentorMetrics | null>(null)
+    const [loading, setLoading] = useState<boolean>(!!initialFetch)
+    const [error, setError] = useState<string | null>(null)
+
+    const getMetrics = useCallback(async () => {
+        try {
+            setLoading(true)
+            setError(null)
+
+            const response = await api.get<MentorMetrics>('/mentor-slots/metrics/me')
+            setMetrics(response.data)
+        } catch (error) {
+            console.error('Error fetching mentor metrics:', error)
+            setMetrics(null)
+            setError(getErrorMessage(error))
+        } finally {
+            setLoading(false)
+        }
+    }, [])
+
+    useEffect(() => {
+        if (initialFetch) getMetrics()
+    }, [initialFetch, getMetrics])
+
+    return {
+        metrics,
+        loading,
+        error,
+        refetchMetrics: getMetrics,
+    }
+}

--- a/src/hooks/useMyMentorSessions.ts
+++ b/src/hooks/useMyMentorSessions.ts
@@ -41,9 +41,17 @@ type WrappedMyMentorSession = {
 
 type MyMentorSessionsPayload = MyMentorSession[] | WrappedMyMentorSession[]
 
+export interface SessionCounts {
+    total?: string | number
+    upcoming?: string | number
+    completed?: string | number
+    cancelled?: string | number
+    reschedule?: string | number
+}
+
 type MyMentorSessionsResponse =
     | MyMentorSessionsPayload
-    | { data: MyMentorSessionsPayload }
+    | { data: MyMentorSessionsPayload; counts?: SessionCounts }
 
 const isWrappedSession = (
     value: MyMentorSession | WrappedMyMentorSession
@@ -81,6 +89,17 @@ const parseSessionsResponse = (
     return []
 }
 
+const parseCountsResponse = (
+    response: MyMentorSessionsResponse
+): SessionCounts => {
+    if (!response || typeof response !== 'object') {
+        return {}
+    }
+
+    const responseWithCounts = response as { counts?: SessionCounts }
+    return responseWithCounts.counts || {}
+}
+
 const getErrorMessage = (error: unknown): string => {
     const message = (error as { response?: { data?: { message?: string } } })
         ?.response?.data?.message
@@ -99,12 +118,16 @@ export type SessionFilter =
     | 'cancelled'
     | 'reschedule'
 
+export type SessionSortOrder = 'asc' | 'desc'
+
 export function useMyMentorSessions(
     initialFetch: boolean,
     endpoint: MyMentorSessionsEndpoint,
-    filter?: SessionFilter
+    filter?: SessionFilter,
+    sort?: SessionSortOrder
 ) {
     const [sessions, setSessions] = useState<MyMentorSession[]>([])
+    const [counts, setCounts] = useState<SessionCounts>({})
     const [loading, setLoading] = useState<boolean>(!!initialFetch)
     const [error, setError] = useState<string | null>(null)
 
@@ -113,18 +136,29 @@ export function useMyMentorSessions(
             setLoading(true)
             setError(null)
 
-            const query = filter ? `?filter=${encodeURIComponent(filter)}` : ''
-            const response = await api.get<MyMentorSessionsResponse>(`${endpoint}${query}`)
+            const queryParams = new URLSearchParams()
+            if (filter) {
+                queryParams.set('filter', filter)
+            }
+            if (sort) {
+                queryParams.set('sort', sort)
+            }
+
+            const query = queryParams.toString()
+            const url = query ? `${endpoint}?${query}` : endpoint
+            const response = await api.get<MyMentorSessionsResponse>(url)
 
             setSessions(parseSessionsResponse(response.data))
+            setCounts(parseCountsResponse(response.data))
         } catch (error) {
             console.error('Error fetching my mentor sessions:', error)
             setSessions([])
+            setCounts({})
             setError(getErrorMessage(error))
         } finally {
             setLoading(false)
         }
-    }, [endpoint, filter])
+    }, [endpoint, filter, sort])
 
     useEffect(() => {
         if (initialFetch) getMySessions()
@@ -132,6 +166,7 @@ export function useMyMentorSessions(
 
     return {
         sessions,
+        counts,
         loading,
         error,
         refetchMySessions: getMySessions,


### PR DESCRIPTION
mentor dashboard and performance metrics pages to use a new `useMentorMetrics` hook for retrieving aggregate mentor statistics, replacing much of the previous manual calculation logic. This leads to more consistent and reliable statistics across the dashboard and performance views, and simplifies the code by removing redundant calculations. It also updates the UI to display metrics from the new source and ensures error/loading states are handled for metric data.
Remove frontend-based filtering and handle it on the backend.
Updated the sessions page to use the new summary counts from `useMyMentorSessions` for the "All" tab count, ensuring consistency with the rest of the dashboard