### PR TITLE
Enhance calendar dashboard and improve performance UI

### DIFF
--- a/src/app/[admin]/mentorsDashboard/calendar/page.tsx
+++ b/src/app/[admin]/mentorsDashboard/calendar/page.tsx
@@ -136,8 +136,7 @@ const slotTop = (slot: MentorCreatedSlot) => {
 const slotHeight = (slot: MentorCreatedSlot) =>
   Math.max((slot.durationMinutes / 60) * HOUR_HEIGHT, 22)
 
-const formatHoursLabel = (slots: MentorCreatedSlot[]) => {
-  const hours = slots.reduce((total, slot) => total + slot.durationMinutes, 0) / 60
+const formatHoursLabel = (hours: number) => {
   return `${Number.isInteger(hours) ? hours : hours.toFixed(1)}h`
 }
 
@@ -418,24 +417,28 @@ export default function CalendarPage() {
   const role = pathname.split("/")[1]
   const today = toDateStr(new Date())
 
-  const [weekStart, setWeekStart] = useState<Date>(() => getMonday(new Date()))
+  const [weekOffset, setWeekOffset] = useState(0)
   const [selectedSlotId, setSelectedSlotId] = useState<number | null>(null)
   const [currentTime, setCurrentTime] = useState(new Date())
   const [selectedMobileDay, setSelectedMobileDay] = useState(0)
 
-  const weekEndExclusive = useMemo(() => addDays(weekStart, 7), [weekStart])
-  const slotFilters = useMemo(
-    () => ({
-      startDateTime: weekStart.toISOString(),
-      endDateTime: weekEndExclusive.toISOString(),
-    }),
-    [weekEndExclusive, weekStart]
-  )
+  const baseWeekStart = useMemo(() => getMonday(new Date()), [])
 
-  const { slots, loading, error, refetchMySlots } = useMyMentorSlots(true, slotFilters)
+  const { slots, metrics, weekStart: apiWeekStart, weekEnd: apiWeekEnd, loading, error, refetchMySlots } = useMyMentorSlots(true, {
+    weekOffset,
+  })
   const { isDeleting, deletingSlotId, error: deleteError, deleteSlot } = useDeleteMentorSlot()
 
   const scrollRef = useRef<HTMLDivElement>(null)
+
+  const weekStart = useMemo(
+    () => (apiWeekStart ? new Date(apiWeekStart) : addDays(baseWeekStart, weekOffset * 7)),
+    [apiWeekStart, baseWeekStart, weekOffset]
+  )
+  const weekEnd = useMemo(
+    () => (apiWeekEnd ? new Date(apiWeekEnd) : addDays(weekStart, 6)),
+    [apiWeekEnd, weekStart]
+  )
 
   const weekDays = useMemo(
     () =>
@@ -446,8 +449,6 @@ export default function CalendarPage() {
       }),
     [weekStart]
   )
-
-  const weekEnd = weekDays[6]
 
   const weekSlots = useMemo(
     () =>
@@ -479,9 +480,15 @@ export default function CalendarPage() {
     [slots, selectedSlotId]
   )
 
-  const isCurrentWeek = useMemo(
-    () => toDateStr(weekStart) <= today && today <= toDateStr(weekEnd),
-    [today, weekEnd, weekStart]
+  const isCurrentWeek = weekOffset === 0
+
+  const displayWeekStart = useMemo(
+    () => (apiWeekStart ? new Date(apiWeekStart) : weekStart),
+    [apiWeekStart, weekStart]
+  )
+  const displayWeekEnd = useMemo(
+    () => (apiWeekEnd ? new Date(apiWeekEnd) : weekEnd),
+    [apiWeekEnd, weekEnd]
   )
 
   const currentTimePx = useMemo(() => {
@@ -489,15 +496,10 @@ export default function CalendarPage() {
     return ((minutes - START_HOUR * 60) / 60) * HOUR_HEIGHT
   }, [currentTime])
 
-  const totalSlots = weekSlots.length
-  const openSlots = weekSlots.filter((slot) => isOpenSlot(slot) && !isBookedSlot(slot)).length
-  const bookedSlots = weekSlots.filter(isBookedSlot).length
-  const totalHours = formatHoursLabel(weekSlots)
-
-  const weekLabel = `${weekStart.toLocaleDateString("en-US", {
+  const weekLabel = `${displayWeekStart.toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
-  })} – ${weekEnd.toLocaleDateString("en-US", {
+  })} – ${displayWeekEnd.toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
     year: "numeric",
@@ -527,15 +529,15 @@ export default function CalendarPage() {
   }, [selectedSlot, selectedSlotId])
 
   const prevWeek = () => {
-    setWeekStart((currentWeekStart) => addDays(currentWeekStart, -7))
+    setWeekOffset((currentOffset) => currentOffset - 1)
   }
 
   const nextWeek = () => {
-    setWeekStart((currentWeekStart) => addDays(currentWeekStart, 7))
+    setWeekOffset((currentOffset) => currentOffset + 1)
   }
 
   const goToToday = () => {
-    setWeekStart(getMonday(new Date()))
+    setWeekOffset(0)
   }
 
   const handleDelete = async (slotId: number) => {
@@ -555,7 +557,7 @@ export default function CalendarPage() {
         <h1 className="text-2xl font-semibold">Calendar</h1>
         <p className="text-sm text-muted-foreground">
           {!loading
-            ? `${totalSlots} slot${totalSlots !== 1 ? "s" : ""} this week`
+            ? `${metrics?.totalSlots ?? 0} slot${(metrics?.totalSlots ?? 0) !== 1 ? "s" : ""} this week`
             : "Your availability at a glance."}
         </p>
       </div>
@@ -841,12 +843,20 @@ export default function CalendarPage() {
                 <CardContent className="space-y-2 p-4 text-left">
                   <p className="text-xs font-bold text-text-primary">This Week</p>
 
-                  <div className="grid grid-cols-2 gap-2">
+                  <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
                     {[
-                      { label: "Total slots", value: totalSlots },
-                      { label: "Open", value: openSlots },
-                      { label: "Booked", value: bookedSlots },
-                      { label: "Hours", value: totalHours },
+                      { label: "Total slots", value: metrics?.totalSlots ?? "-" },
+                      { label: "Available", value: metrics?.available ?? "-" },
+                      { label: "Full", value: metrics?.full ?? "-" },
+                      { label: "Completed", value: metrics?.completed ?? "-" },
+                      { label: "Closed", value: metrics?.closed ?? "-" },
+                      {
+                        label: "Hours",
+                        value:
+                          typeof metrics?.hours === "number"
+                            ? formatHoursLabel(metrics.hours)
+                            : "-",
+                      },
                     ].map(({ label, value }) => (
                       <div key={label} className="rounded-lg bg-muted p-2 text-center">
                         <p className="text-base font-bold tabular-nums text-text-primary">{value}</p>
@@ -858,30 +868,6 @@ export default function CalendarPage() {
               </Card>
             </div>
           </div>
-        )}
-
-        {!loading && !error && slots.length === 0 && (
-          <Card className="rounded-xl border border-dashed border-border bg-card shadow-sm">
-            <CardContent className="flex flex-col items-center gap-4 py-16 text-center">
-              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted">
-                <CalendarX className="h-7 w-7 text-text-muted" />
-              </div>
-
-              <div>
-                <p className="text-sm font-semibold text-text-primary">No availability slots yet</p>
-                <p className="mt-1 text-xs text-text-muted">
-                  Create slots so learners can book sessions with you
-                </p>
-              </div>
-
-              <Button asChild className="gap-1.5 bg-primary text-primary-foreground hover:bg-primary-dark">
-                <Link href={`/${role}/mentorsDashboard/availability`}>
-                  <Plus className="h-4 w-4" />
-                  Create Availability
-                </Link>
-              </Button>
-            </CardContent>
-          </Card>
         )}
       </div>
     </div>

--- a/src/app/[admin]/mentorsDashboard/dashboard/page.tsx
+++ b/src/app/[admin]/mentorsDashboard/dashboard/page.tsx
@@ -169,18 +169,12 @@ const getLearnerLabel = (session: MyMentorSession) => {
 export default function DashboardPage() {
   const pathname = usePathname()
   const role = pathname.split("/")[1]
-  const initialNowIso = useMemo(() => new Date().toISOString(), [])
 
   const {
     slots,
     loading: slotsLoading,
     error: slotsError,
-  } = useMyMentorSlots(true, { startDateTime: initialNowIso })
-  const {
-    sessions,
-    loading: sessionsLoading,
-    error: sessionsError,
-  } = useMyMentorSessions(true, "/mentor-sessions/mentor/my")
+  } = useMyMentorSlots(true)
   const {
     sessions: completedSessions,
     loading: completedSessionsLoading,
@@ -195,7 +189,6 @@ export default function DashboardPage() {
     notifications: apiNotifications,
     loading: notificationsLoading,
     error: notificationsError,
-    unreadCount,
     markAsRead,
     markAllAsRead,
     markingRead,
@@ -219,8 +212,8 @@ export default function DashboardPage() {
     [slots]
   )
 
-  const sessionsDataLoading = sessionsLoading || completedSessionsLoading || metricsLoading
-  const sessionsDataError = sessionsError || completedSessionsError || metricsError
+  const sessionsDataLoading = completedSessionsLoading || metricsLoading
+  const sessionsDataError = completedSessionsError || metricsError
 
   const recentCompletedSessions = useMemo(
     () =>
@@ -240,80 +233,17 @@ export default function DashboardPage() {
     [completedSessions]
   )
 
-  const openSlots = useMemo(
-    () => slots.filter((slot) => slot.status.toLowerCase() === "available").length,
-    [slots]
-  )
-
-  const completionRate = (() => {
-    const totalCount = Number(metrics?.sessions.total) || 0
-    const completedCount = Number(metrics?.sessions.completed) || 0
-    return totalCount === 0 ? 0 : Math.round((completedCount / totalCount) * 100)
-  })()
-
-  const totalHoursScheduled = useMemo(
-    () => slots.reduce((sum, slot) => sum + slot.durationMinutes, 0) / 60,
-    [slots]
-  )
-
-  const slotDurationById = useMemo(() => {
-    const durationById = new Map<number, number>()
-
-    for (const slot of slots) {
-      durationById.set(slot.id, slot.durationMinutes)
-    }
-
-    return durationById
-  }, [slots])
-
-  const hoursDelivered = useMemo(() => {
-    const deliveredMinutes = completedSessions.reduce((sum, session) => {
-      const slotDuration = slotDurationById.get(session.slotAvailabilityId) || 0
-      if (slotDuration > 0) {
-        return sum + slotDuration
-      }
-
-      const joinedAt = getDateValue(session.joinedAt)
-      const completedAt = getDateValue(session.completedAt)
-
-      if (!joinedAt || !completedAt) {
-        return sum
-      }
-
-      const sessionDurationMinutes = Math.round(
-        (completedAt.getTime() - joinedAt.getTime()) / (60 * 1000)
-      )
-
-      return sessionDurationMinutes > 0 ? sum + sessionDurationMinutes : sum
-    }, 0)
-
-    return deliveredMinutes / 60
-  }, [completedSessions, slotDurationById])
-
-  const uniqueLearners = useMemo(() => {
-    const learnerKeys = new Set<string>()
-
-    for (const session of sessions) {
-      if (typeof session.studentUserId === "number") {
-        learnerKeys.add(`id:${session.studentUserId}`)
-        continue
-      }
-
-      const learnerLabel = getLearnerLabel(session)
-      if (learnerLabel !== "A learner") {
-        learnerKeys.add(`name:${learnerLabel.toLowerCase()}`)
-      }
-    }
-
-    return learnerKeys.size
-  }, [sessions])
+  const upcomingSessionsCount = Number(metrics?.upcomingSessions) || 0
+  const completionRate = Number(metrics?.sessions.completionRate) || 0
+  const cancellationRate = Number(metrics?.sessions.cancellationRate) || 0
+  const utilizationRate = Number(metrics?.utilization.utilizationRate) || 0
 
   return (
     <div className="space-y-6">
       <div className="text-left">
         <h1 className="text-2xl font-semibold">Dashboard</h1>
         <p className="text-sm text-muted-foreground">
-          {upcomingSlots.length} upcoming slots scheduled
+          {upcomingSessionsCount} Upcoming Sessions Scheduled
         </p>
       </div>
 
@@ -325,9 +255,9 @@ export default function DashboardPage() {
                 <Calendar className="w-5 h-5 text-muted-foreground" />
                 </div>
                 <div className="text-left">
-                    <p className="text-2xl font-bold">{upcomingSlots.length}</p>
-                    <p className="text-sm text-muted-foreground">Upcoming Slots</p>
-                    <p className="text-sm  mt-4">{openSlots} still open</p>
+                  <p className="text-2xl font-bold">{upcomingSessionsCount}</p>
+                  <p className="text-sm text-muted-foreground">Upcoming Sessions</p>
+                  <p className="text-sm  mt-4">Next on your schedule</p>
                 </div>
             </div>
 
@@ -363,7 +293,7 @@ export default function DashboardPage() {
             <div className="text-left">
               <p className="text-2xl font-bold">{Number(metrics?.sessions.total) || 0}</p>
               <p className="text-sm text-muted-foreground">Bookings Managed</p>
-              <p className="text-sm  mt-4">all lifecycle states</p>
+              <p className="text-sm  mt-4">All session states</p>
             </div>
             </div>
             <div className="flex flex-col items-end gap-2">
@@ -509,39 +439,29 @@ export default function DashboardPage() {
               </div>
               <div className="bg-slate-50/50 rounded-xl p-4 border ">
                 <div className="flex items-center gap-2 mb-2">
-                   <Star className="w-3.5 h-3.5 text-emerald-600" />
-                   <span className="text-xs font-semibold text-slate-600">Avg Rating</span>
+                   <Calendar className="w-3.5 h-3.5 text-emerald-600" />
+                   <span className="text-xs font-semibold text-slate-600">Upcoming Sessions</span>
                 </div>
-                <p className="text-2xl font-bold mb-2">{metrics?.ratings.averageRating ? Number(metrics.ratings.averageRating).toFixed(1) : "—"}</p>
-                <div className="flex gap-0.5">
-                  {[...Array(5)].map((_, i) => (
-                    <Star
-                      key={i}
-                      className={cn(
-                        "w-3 h-3",
-                        metrics?.ratings.averageRating && i < Math.round(Number(metrics.ratings.averageRating))
-                          ? "fill-emerald-500 text-emerald-500"
-                          : "fill-transparent text-emerald-200"
-                      )}
-                    />
-                  ))}
-                </div>
+                <p className="text-2xl font-bold mb-2">{upcomingSessionsCount}</p>
+                <p className="text-xs text-slate-500">Next scheduled sessions</p>
               </div>
-               <div className="rounded-lg bg-muted/50 p-3">
-                    <div className="flex items-center gap-1.5 mb-2">
-                      <Clock className="h-3.5 w-3.5 text-info" />
-                      <p className="text-xs font-medium text-text-secondary">Hours Delivered</p>
+               <div className="bg-slate-50/50 rounded-xl p-4 border">
+                <div className="flex items-center gap-1.5 mb-2">
+                      <Clock className="h-3.5 w-3.5 text-secondary" />
+                      <p className="text-xs font-medium text-text-secondary">Cancellation Rate</p>
                     </div>
-                    <p className="text-2xl font-bold text-text-primary tabular-nums">{hoursDelivered}h</p>
-                    <p className="text-[10px] text-text-muted mt-1">Across {Number(metrics?.sessions.completed) || 0} sessions</p>
-                </div>
+                    <p className="text-2xl font-bold text-text-primary tabular-nums">{cancellationRate}%</p>
+                    <p className="text-[10px] text-text-muted mt-1">Based on session history</p>
+              </div>
                <div className="bg-slate-50/50 rounded-xl p-4 border">
                 <div className="flex items-center gap-1.5 mb-2">
                       <Users className="h-3.5 w-3.5 text-secondary" />
-                      <p className="text-xs font-medium text-text-secondary">Learners Helped</p>
+                      <p className="text-xs font-medium text-text-secondary">Utilization Rate</p>
                     </div>
-                    <p className="text-2xl font-bold text-text-primary tabular-nums">{uniqueLearners}</p>
-                    <p className="text-[10px] text-text-muted mt-1">Unique learners</p>
+                    <p className="text-2xl font-bold text-text-primary tabular-nums">{utilizationRate}%</p>
+                    <p className="text-[10px] text-text-muted mt-1">
+                      {Number(metrics?.utilization.usedSlots) || 0}/{Number(metrics?.utilization.totalSlots) || 0} slots booked
+                    </p>
               </div>
             </CardContent>
           </Card>
@@ -552,13 +472,8 @@ export default function DashboardPage() {
             <CardHeader className="flex flex-row items-center justify-between pb-3">
               <div className="flex items-center gap-2">
                 <CardTitle className="text-left">Notifications</CardTitle>
-                {unreadCount > 0 && (
-                  <span className="flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white">
-                    {unreadCount > 9 ? "9+" : unreadCount}
-                  </span>
-                )}
               </div>
-              {unreadCount > 0 && (
+              {apiNotifications.some((notification) => !notification.isRead) && (
                 <button
                   onClick={markAllAsRead}
                   className="flex items-center gap-1 text-xs text-emerald-700 font-semibold hover:underline"

--- a/src/app/[admin]/mentorsDashboard/performance/page.tsx
+++ b/src/app/[admin]/mentorsDashboard/performance/page.tsx
@@ -35,17 +35,6 @@ const formatCompletedDateTime = (value?: string | null) => {
   })
 }
 
-const getSessionDurationMinutes = (slotStart?: string | null, slotEnd?: string | null) => {
-  if (!slotStart || !slotEnd) return 0
-
-  const start = new Date(slotStart)
-  const end = new Date(slotEnd)
-
-  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return 0
-
-  return Math.max(0, Math.round((end.getTime() - start.getTime()) / (1000 * 60)))
-}
-
 const getDisplayStudentName = (
   studentName?: string | null,
   studentUserName?: string | null,
@@ -73,22 +62,10 @@ const renderRatingStars = (rating?: number | null) => {
 
 export default function PerformanceMetrics() {
   const {
-    sessions: allSessions,
-    loading: allSessionsLoading,
-    error: allSessionsError,
-  } = useMyMentorSessions(true, "/mentor-sessions/mentor/my")
-
-  const {
     sessions: completedSessions,
     loading: completedSessionsLoading,
     error: completedSessionsError,
   } = useMyMentorSessions(true, "/mentor-sessions/mentor/my", "completed", "desc")
-
-  const {
-    sessions: upcomingSlots,
-    loading: upcomingSessionsLoading,
-    error: upcomingSessionsError,
-  } = useMyMentorSessions(true, "/mentor-sessions/mentor/my", "upcoming")
 
   const {
     metrics,
@@ -96,28 +73,9 @@ export default function PerformanceMetrics() {
     error: metricsError,
   } = useMentorMetrics(true)
 
-  const completionRate = (() => {
-    const totalCount = Number(metrics?.sessions.total) || 0
-    const completedCount = Number(metrics?.sessions.completed) || 0
-    return totalCount === 0 ? 0 : Math.round((completedCount / totalCount) * 100)
-  })()
-
-  const totalScheduledMinutes = useMemo(
-    () =>
-      allSessions.reduce(
-        (sum, session) =>
-          sum + getSessionDurationMinutes(session.slotStart, session.slotEnd),
-        0
-      ),
-    [allSessions]
-  )
-
-  const averageSessionLength = (() => {
-    const totalCount = Number(metrics?.sessions.total) || 0
-    return totalCount === 0 ? 0 : Math.round(totalScheduledMinutes / totalCount)
-  })()
-
-  const totalScheduledHours = totalScheduledMinutes / 60
+  const completionRate = Number(metrics?.sessions.completionRate) || 0
+  const cancellationRate = Number(metrics?.sessions.cancellationRate) || 0
+  const utilizationRate = Number(metrics?.utilization.utilizationRate) || 0
 
   const recentCompleted = completedSessions
 
@@ -130,19 +88,15 @@ export default function PerformanceMetrics() {
     const completedCount = Number(metrics?.sessions.completed) || 0
     const cancelledCount = Number(metrics?.sessions.cancelled) || 0
     const upcomingCount = Number(metrics?.upcomingSessions) || 0
-    
-    // Calculate reschedule count from all sessions by filtering for status
-    const rescheduleCount = allSessions.filter(
-      session => session.status?.toLowerCase() === "rescheduled"
-    ).length
+    const missedCount = Number(metrics?.sessions.missed) || 0
 
     return [
       { label: "Completed", value: completedCount, barClass: "bg-green-600" },
       { label: "Upcoming", value: upcomingCount, barClass: "bg-emerald-400" },
       { label: "Cancelled", value: cancelledCount, barClass: "bg-gray-400" },
-      { label: "Reschedule", value: rescheduleCount, barClass: "bg-orange-400" },
+      { label: "Missed", value: missedCount, barClass: "bg-orange-400" },
     ]
-  }, [metrics?.sessions.cancelled, metrics?.sessions.completed, metrics?.upcomingSessions, allSessions])
+  }, [metrics?.sessions.cancelled, metrics?.sessions.completed, metrics?.sessions.missed, metrics?.upcomingSessions])
 
   const maxSessionMixValue = useMemo(
     () => Math.max(1, ...sessionMix.map((item) => item.value)),
@@ -183,17 +137,19 @@ export default function PerformanceMetrics() {
 
         <Card className='rounded-3xl'>
           <CardContent className="p-5 text-left">
-            <p className="text-2xl font-semibold">{totalScheduledHours.toFixed(1)}h</p>
-            <p className="text-sm font-medium">Scheduled Hours</p>
-            <p className="text-xs text-muted-foreground">Across {Number(metrics?.sessions.total) || 0} sessions</p>
+            <p className="text-2xl font-semibold">{utilizationRate}%</p>
+            <p className="text-sm font-medium">Utilization Rate</p>
+            <p className="text-xs text-muted-foreground">
+              {Number(metrics?.utilization.usedSlots) || 0} of {Number(metrics?.utilization.totalSlots) || 0} slots booked
+            </p>
           </CardContent>
         </Card>
 
         <Card className='rounded-3xl'>
           <CardContent className="p-5 text-left">
             <p className="text-2xl font-semibold">{Number(metrics?.upcomingSessions) || 0}</p>
-            <p className="text-sm font-medium">Upcoming Slots</p>
-            <p className="text-xs text-muted-foreground">Booked + open upcoming schedule</p>
+            <p className="text-sm font-medium">Upcoming Sessions</p>
+            <p className="text-xs text-muted-foreground">Sessions scheduled next</p>
           </CardContent>
         </Card>
       </div>
@@ -217,8 +173,8 @@ export default function PerformanceMetrics() {
               </div>
 
               <div className="bg-gray-100 rounded-3xl p-3 text-center">
-                <p className="font-semibold">{averageSessionLength}m</p>
-                <p className="text-xs text-muted-foreground">Avg duration</p>
+                <p className="font-semibold">{cancellationRate}%</p>
+                <p className="text-xs text-muted-foreground">Cancelled rate</p>
               </div>
             </div>
 
@@ -241,19 +197,16 @@ export default function PerformanceMetrics() {
             </div>
 
             <div className="mt-4 space-y-2 text-left">
-              {(allSessionsLoading || completedSessionsLoading || upcomingSessionsLoading) && (
+              {(completedSessionsLoading || metricsLoading) && (
                 <p className="text-xs text-muted-foreground">Loading session analytics...</p>
-              )}
-              {!allSessionsLoading && allSessionsError && (
-                <p className="text-xs text-red-500">{allSessionsError}</p>
               )}
               {!completedSessionsLoading && completedSessionsError && (
                 <p className="text-xs text-red-500">{completedSessionsError}</p>
               )}
-              {!upcomingSessionsLoading && upcomingSessionsError && (
-                <p className="text-xs text-red-500">{upcomingSessionsError}</p>
+              {!metricsLoading && metricsError && (
+                <p className="text-xs text-red-500">{metricsError}</p>
               )}
-              {!allSessionsLoading && !allSessionsError && (Number(metrics?.sessions.total) || 0) === 0 && (
+              {!metricsLoading && !metricsError && (Number(metrics?.sessions.total) || 0) === 0 && (
                 <p className="text-xs text-muted-foreground">No sessions yet.</p>
               )}
             </div>
@@ -306,16 +259,16 @@ export default function PerformanceMetrics() {
         <Card className='rounded-3xl'>
           <CardContent className="p-5 text-left">
             <p className="text-xl font-semibold">{Number(metrics?.upcomingSessions) || 0}</p>
-            <p className="text-sm font-medium">Upcoming Slots</p>
-            <p className="text-xs text-muted-foreground">Current future availability</p>
+            <p className="text-sm font-medium">Upcoming Sessions</p>
+            <p className="text-xs text-muted-foreground">Scheduled for upcoming dates</p>
           </CardContent>
         </Card>
 
         <Card className='rounded-3xl'>
           <CardContent className="p-5 text-left">
-            <p className="text-xl font-semibold">{averageSessionLength}m</p>
-            <p className="text-sm font-medium">Avg Slot Length</p>
-            <p className="text-xs text-muted-foreground">Based on mentor sessions</p>
+            <p className="text-xl font-semibold">{Number(metrics?.sessions.missed) || 0}</p>
+            <p className="text-sm font-medium">Missed Sessions</p>
+            <p className="text-xs text-muted-foreground">Sessions marked as missed</p>
           </CardContent>
         </Card>
 
@@ -324,13 +277,10 @@ export default function PerformanceMetrics() {
             <p className="text-xl font-semibold">{Number(metrics?.sessions.total) || 0}</p>
             <p className="text-sm font-medium">Total Sessions</p>
             <p className="text-xs text-muted-foreground">
-              {(allSessionsLoading || completedSessionsLoading || upcomingSessionsLoading || metricsLoading)
+              {(completedSessionsLoading || metricsLoading)
                 ? "Loading..."
-                : "Fetched from /mentor-slots/metrics/me"}
+                : "All tracked mentor sessions"}
             </p>
-            {!allSessionsLoading && allSessionsError && (
-              <p className="text-xs text-red-500 mt-1">{allSessionsError}</p>
-            )}
             {!metricsLoading && metricsError && (
               <p className="text-xs text-red-500 mt-1">{metricsError}</p>
             )}

--- a/src/hooks/useMyMentorSlots.ts
+++ b/src/hooks/useMyMentorSlots.ts
@@ -14,15 +14,38 @@ export interface MentorCreatedSlot {
     status: string
 }
 
+export interface MentorSlotMetrics {
+    totalSlots: number
+    available: number
+    full: number
+    completed: number
+    closed: number
+    hours: number
+}
+
 type UpsertMySlotPayload = Omit<MentorCreatedSlot, 'mentorSlotManagementId'> & {
     mentorSlotManagementId?: number
 }
 
-type MyMentorSlotsApiResponse = MentorCreatedSlot[] | { data: MentorCreatedSlot[] }
+type MyMentorSlotsApiResponse =
+    | MentorCreatedSlot[]
+    | {
+          data?: MentorCreatedSlot[]
+          slots?: MentorCreatedSlot[]
+          weekStart?: string
+          weekEnd?: string
+          metrics?: MentorSlotMetrics
+      }
 
 export interface MyMentorSlotsFilters {
-    startDateTime?: string
-    endDateTime?: string
+    weekOffset?: number
+}
+
+export interface MyMentorSlotsResponse {
+    slots: MentorCreatedSlot[]
+    metrics: MentorSlotMetrics | null
+    weekStart: string | null
+    weekEnd: string | null
 }
 
 const parseMySlotsResponse = (
@@ -32,11 +55,35 @@ const parseMySlotsResponse = (
         return response
     }
 
+    if (response && Array.isArray(response.slots)) {
+        return response.slots
+    }
+
     if (response && Array.isArray(response.data)) {
         return response.data
     }
 
     return []
+}
+
+const parseMyMentorSlotsPayload = (
+    response: MyMentorSlotsApiResponse
+): MyMentorSlotsResponse => {
+    if (Array.isArray(response)) {
+        return {
+            slots: response,
+            metrics: null,
+            weekStart: null,
+            weekEnd: null,
+        }
+    }
+
+    return {
+        slots: parseMySlotsResponse(response),
+        metrics: response?.metrics ?? null,
+        weekStart: response?.weekStart ?? null,
+        weekEnd: response?.weekEnd ?? null,
+    }
 }
 
 const getErrorMessage = (error: unknown): string => {
@@ -51,6 +98,9 @@ export function useMyMentorSlots(
     filters?: MyMentorSlotsFilters
 ) {
     const [slots, setSlots] = useState<MentorCreatedSlot[]>([])
+    const [metrics, setMetrics] = useState<MentorSlotMetrics | null>(null)
+    const [weekStart, setWeekStart] = useState<string | null>(null)
+    const [weekEnd, setWeekEnd] = useState<string | null>(null)
     const [loading, setLoading] = useState<boolean>(!!initialFetch)
     const [error, setError] = useState<string | null>(null)
 
@@ -63,25 +113,30 @@ export function useMyMentorSlots(
                 '/mentor-slots/my',
                 {
                     params: {
-                        ...(filters?.startDateTime
-                            ? { startDateTime: filters.startDateTime }
-                            : {}),
-                        ...(filters?.endDateTime
-                            ? { endDateTime: filters.endDateTime }
+                        ...(typeof filters?.weekOffset === 'number'
+                            ? { weekOffset: filters.weekOffset }
                             : {}),
                     },
                 }
             )
 
-            setSlots(parseMySlotsResponse(response.data))
+            const payload = parseMyMentorSlotsPayload(response.data)
+
+            setSlots(payload.slots)
+            setMetrics(payload.metrics)
+            setWeekStart(payload.weekStart)
+            setWeekEnd(payload.weekEnd)
         } catch (error) {
             console.error('Error fetching my mentor slots:', error)
             setSlots([])
+            setMetrics(null)
+            setWeekStart(null)
+            setWeekEnd(null)
             setError(getErrorMessage(error))
         } finally {
             setLoading(false)
         }
-    }, [filters?.endDateTime, filters?.startDateTime])
+    }, [filters?.weekOffset])
 
     const upsertMySlot = useCallback((slot: UpsertMySlotPayload) => {
         const normalizedSlot: MentorCreatedSlot = {
@@ -110,6 +165,9 @@ export function useMyMentorSlots(
 
     return {
         slots,
+        metrics,
+        weekStart,
+        weekEnd,
         loading,
         error,
         refetchMySlots: getMySlots,


### PR DESCRIPTION
mentor dashboard and calendar pages to centralize and standardize metrics and statistics by relying on the backend-provided `metrics` object. It removes redundant local calculations, simplifies state management for week navigation, and updates the UI to use new and more accurate metrics fields. The result is a more maintainable codebase with improved consistency across the dashboard, calendar, and performance pages.
**Metrics and Statistics Refactor:**
* Replaced local calculations of slot/session statistics (e.g., total slots, open/booked slots, hours, completion/cancellation/utilization rates) with values from the backend `metrics` object throughout the dashboard, calendar, and performance pages. This ensures consistency and reduces code duplication. 
**Calendar Week Navigation and State Management:**
* Simplified week navigation in the calendar by introducing a `weekOffset` state instead of storing the week start date directly, and updated all logic to use this offset for calculating the current week. 
**API and Data Fetching Updates:**
* Updated hooks (`useMyMentorSlots`, `useMyMentorSessions`) to remove unnecessary filters and parameters, relying on backend filtering and metrics aggregation.
**UI and Code Cleanup:**
* Removed redundant and now-unused code for calculating statistics, session durations, and learner counts on the frontend. 