### PR TITLE
Fix text overflow in mentor bio section of profile

### DIFF
--- a/src/app/student/mentors/[id]/page.tsx
+++ b/src/app/student/mentors/[id]/page.tsx
@@ -179,7 +179,9 @@ export default function MentorProfilePage() {
             </p>
 
             {mentorProfile?.bio ? (
-              <p className="text-sm text-gray-700">{mentorProfile.bio}</p>
+              <p className="text-sm text-gray-700 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+                {mentorProfile.bio}
+              </p>
             ) : (
               <p className="text-sm text-gray-400 italic">
                 This mentor has not added a bio yet.


### PR DESCRIPTION
This pull request makes a small improvement to the display of mentor bios on the mentor profile page. The change ensures that bios with line breaks and long words are displayed correctly, improving readability for users.

* Improved mentor bio formatting: Updated the `<p>` tag displaying `mentorProfile.bio` to use CSS classes `whitespace-pre-wrap`, `break-words`, and `[overflow-wrap:anywhere]` so that line breaks are preserved and long words/wrapped text display properly. ([src/app/student/mentors/[id]/page.tsxL182-R184](diffhunk://#diff-baec25d2a7193a92554a9e3ba958f552461af43654a0df14020b098ce44bdd4bL182-R184))