### PR TITLE
Replace zoomStartUrl with meetLink and add booking limit validation UI

### DIFF
--- a/src/app/[admin]/mentorsDashboard/sessions/page.tsx
+++ b/src/app/[admin]/mentorsDashboard/sessions/page.tsx
@@ -217,7 +217,7 @@ export default function SessionsPage() {
   const isRescheduleTab = activeTab === "reschedule"
 
   const canJoinSelectedSession = Boolean(
-    selectedSession?.zoomStartUrl?.trim() &&
+    selectedSession?.meetingLink?.trim() &&
     isJoinWindowOpen(selectedSession?.slotStart, selectedSession?.slotEnd, nowTimestamp)
   )
 
@@ -657,13 +657,13 @@ export default function SessionsPage() {
                     {selectedSession.sessionLifecycleState}
                   </Badge>
                 </div>
-                {!isRescheduleTab && selectedSession.sessionLifecycleState !== "COMPLETED" && !isReadOnlySession && selectedSession.zoomStartUrl && !canJoinSelectedSession && (
+                {!isRescheduleTab && selectedSession.sessionLifecycleState !== "COMPLETED" && !isReadOnlySession && selectedSession.meetingLink && !canJoinSelectedSession && (
                   <p className="text-xs text-muted-foreground">
                     Join opens 10 min before start
                   </p>
                 )}
                 {!isRescheduleTab && selectedSession.sessionLifecycleState !== "COMPLETED" && !isReadOnlySession && (
-                  selectedSession.zoomStartUrl ? (
+                  selectedSession.meetingLink ? (
                     <Button
                       type="button"
                       className="bg-green-700 hover:bg-green-800"
@@ -672,7 +672,7 @@ export default function SessionsPage() {
                     >
                       {canJoinSelectedSession ? (
                         <a
-                          href={selectedSession.zoomStartUrl}
+                          href={selectedSession.meetingLink}
                           target="_blank"
                           rel="noopener noreferrer"
                         >

--- a/src/app/student/_components/MentorBookingDrawer.tsx
+++ b/src/app/student/_components/MentorBookingDrawer.tsx
@@ -8,6 +8,7 @@ import type { MentorAvailabilitySlot } from "@/hooks/useMentorAvailability"
 import { useMentorAvailability } from "@/hooks/useMentorAvailability"
 import { useBookMentorSlot } from "@/hooks/useBookMentorSlot"
 import { useMentorProfile } from "@/hooks/useMentorProfile"
+import { useStudentMentorMetrics } from "@/hooks/useStudentMentorMetrics"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Sheet, SheetContent, SheetHeader, SheetTitle  } from "@/components/ui/sheet"
@@ -66,6 +67,8 @@ export default function MentorBookingDrawer({
   )
   const { isBooking, error: bookingError, bookSlot } = useBookMentorSlot()
 
+  const { metrics, loading: metricsLoading } = useStudentMentorMetrics(Boolean(open && mentor?.userId))
+
   useEffect(() => {
     if (!open) {
       setSelectedSlotId(null)
@@ -97,7 +100,10 @@ export default function MentorBookingDrawer({
   const pastExperiences = (mentorProfile?.pastExperiences || listPastExperiences || "").trim()
   const aboutText = (mentorProfile?.bio || mentor?.bio || "").trim()
   const initials = mentor ? getInitials(mentor.name) : "M"
-  const canBook = !!mentor && isAvailable && selectedSlotId !== null && !isBooking
+  const bookingEligibilityBlocked = Boolean(metrics && metrics.canBook === false)
+  const bookingNotYetEligible = Boolean(metrics && metrics.nextEligible && new Date(metrics.nextEligible).getTime() > Date.now())
+
+  const canBook = !!mentor && isAvailable && selectedSlotId !== null && !isBooking && !bookingEligibilityBlocked && !bookingNotYetEligible
 
   const handleBook = async () => {
     if (selectedSlotId === null) return
@@ -111,6 +117,14 @@ export default function MentorBookingDrawer({
     setSelectedSlotId(null)
     refetchMentorAvailability()
     setBookingSuccess(true)
+  }
+
+  const formatEligibleDate = (dateString?: string | null) => {
+    if (!dateString) return ""
+    const d = new Date(dateString)
+    if (Number.isNaN(d.getTime())) return ""
+
+    return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' })
   }
 
   return (
@@ -371,10 +385,24 @@ export default function MentorBookingDrawer({
               <div className="sticky bottom-0 border-t border-gray-200 bg-white px-6 py-4">
                 <div className="space-y-2">
                   {bookingError ? <p className="text-xs text-red-500">{bookingError}</p> : null}
+
+                  {/* Validation message when user cannot book */}
+                  {selectedSlotId !== null && (bookingEligibilityBlocked || bookingNotYetEligible) && (
+                    <div className="rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-sm text-yellow-800">
+                      {bookingEligibilityBlocked ? (
+                        <>
+                          You have already booked a session. {metrics?.nextEligible ? `Your next booking will be available on ${formatEligibleDate(metrics.nextEligible)}.` : null}
+                        </>
+                      ) : bookingNotYetEligible ? (
+                        <>You can book your next session from {formatEligibleDate(metrics?.nextEligible || null)}.</>
+                      ) : null}
+                    </div>
+                  )}
+
                   <Button
                     onClick={handleBook}
                     disabled={!canBook}
-                    className="h-10 w-full bg-green-800 text-white hover:bg-green-900 text-sm font-medium"
+                    className="h-10 w-full bg-green-800 text-white hover:bg-green-900 text-sm font-medium cursor-not-allowed"
                   >
                     {isBooking ? "Booking..." : "Book this Session"}
                   </Button>

--- a/src/app/student/sessions/page.tsx
+++ b/src/app/student/sessions/page.tsx
@@ -398,7 +398,7 @@ export default function MySessions() {
         ))
       : activeTab === "upcoming" && counts.upcoming > 0 ?
         sessions.map((session) => {
-          const joinUrl = session.zoomStartUrl?.trim() || ""
+          const joinUrl = session.meetingLink?.trim() || ""
           const canJoinNow = !!joinUrl && isJoinWindowOpen(session.slotStart, session.slotEnd, nowTimestamp)
 
           return (

--- a/src/hooks/useMyMentorSessions.ts
+++ b/src/hooks/useMyMentorSessions.ts
@@ -11,7 +11,6 @@ export interface MyMentorSession {
     status: string
     sessionLifecycleState: string
     meetingLink?: string | null
-    zoomStartUrl?: string | null
     isZoomMeet?: boolean | null
     joinedAt: string | null
     completedAt: string | null


### PR DESCRIPTION
This pull request introduces two main improvements: (1) it standardizes the use of the `meetingLink` property in place of the deprecated `zoomStartUrl` throughout the codebase for session joining functionality, and (2) it enhances the mentor booking drawer for students by adding eligibility checks and user feedback on booking restrictions. These changes improve code consistency and provide a better user experience.

**Session joining and meeting link standardization:**

- Replaced all usage of `zoomStartUrl` with `meetingLink` in both the mentor and student session pages, ensuring that session joining and related UI logic consistently use the new property. (`src/app/[admin]/mentorsDashboard/sessions/page.tsx`, `src/app/student/sessions/page.tsx`, `src/hooks/useMyMentorSessions.ts`) ([src/app/[admin]/mentorsDashboard/sessions/page.tsxL220-R220](diffhunk://#diff-a5363d31fe3be9826bed5d443e541279c39a5bebcd59e4a51765ff813bd5fac0L220-R220), [src/app/[admin]/mentorsDashboard/sessions/page.tsxL660-R666](diffhunk://#diff-a5363d31fe3be9826bed5d443e541279c39a5bebcd59e4a51765ff813bd5fac0L660-R666), [src/app/[admin]/mentorsDashboard/sessions/page.tsxL675-R675](diffhunk://#diff-a5363d31fe3be9826bed5d443e541279c39a5bebcd59e4a51765ff813bd5fac0L675-R675), [[1]](diffhunk://#diff-640b6bfc0e4e388a4181f14d959fff3087dd722e78caae0df7ff91293fc78530L401-R401) [[2]](diffhunk://#diff-e11da398ab22c750117bc831895f8068778ee202a29b4789ef2192b5ab2733a2L14)

**Mentor booking eligibility and feedback:**

- Integrated `useStudentMentorMetrics` into the student mentor booking drawer to check if the student is eligible to book a session, blocking the booking button and displaying informative messages when the user is ineligible (e.g., already booked or not yet eligible). (`src/app/student/_components/MentorBookingDrawer.tsx`) [[1]](diffhunk://#diff-c782cdc7042a061619a0ad6a0c610dc30160988366513014bc4e5788f6cf1c18R11) [[2]](diffhunk://#diff-c782cdc7042a061619a0ad6a0c610dc30160988366513014bc4e5788f6cf1c18R70-R71) [[3]](diffhunk://#diff-c782cdc7042a061619a0ad6a0c610dc30160988366513014bc4e5788f6cf1c18L100-R106) [[4]](diffhunk://#diff-c782cdc7042a061619a0ad6a0c610dc30160988366513014bc4e5788f6cf1c18R122-R129) [[5]](diffhunk://#diff-c782cdc7042a061619a0ad6a0c610dc30160988366513014bc4e5788f6cf1c18R388-R405)

These updates ensure a more robust and user-friendly session management and booking experience.