### PR TITLE
fix: remove bootcamp validation from mentor profile form

### DIFF
--- a/src/app/[admin]/organizations/[organizationId]/profile/page.tsx
+++ b/src/app/[admin]/organizations/[organizationId]/profile/page.tsx
@@ -60,8 +60,6 @@ function MentorProfileCreateUI({
     [courses]
   )
   const bootcampId = mentorshipEnabledBootcamp?.id ?? null
-  const hasResolvedBootcamp =
-    typeof bootcampId === 'number' && Number.isFinite(bootcampId) && bootcampId > 0
 
   const {
     mentorProfile,
@@ -131,7 +129,6 @@ function MentorProfileCreateUI({
     if (!pastExperiences.trim()) validationErrors.push('Past experiences are required.')
     if (bio.trim().length < 80) validationErrors.push('Bio should be at least 80 characters.')
     if (expertise.length === 0) validationErrors.push('Please add at least one skill.')
-    if (!hasResolvedBootcamp) validationErrors.push('No bootcamp is available for this organization yet.')
 
     if (validationErrors.length > 0) {
       toast.error({
@@ -140,8 +137,6 @@ function MentorProfileCreateUI({
       })
       return
     }
-
-    const resolvedBootcampId = bootcampId as number
 
     try {
       // Use POST only when there is no existing mentor profile (first-time)


### PR DESCRIPTION
This pull request simplifies the mentor profile creation logic by removing the requirement for a resolved bootcamp to be present when validating the form. This change makes it possible to create a mentor profile even if no bootcamp is available for the organization.

Validation logic update:

* Removed the check that required a resolved bootcamp (`hasResolvedBootcamp`) before allowing mentor profile creation, and eliminated the associated validation error message. ([src/app/[admin]/organizations/[organizationId]/profile/page.tsxL63-L64](diffhunk://#diff-ecea50bc88354f97ffed3d9825c09379c638ca98d212d7c545d5c38de5dd7591L63-L64), [src/app/[admin]/organizations/[organizationId]/profile/page.tsxL134](diffhunk://#diff-ecea50bc88354f97ffed3d9825c09379c638ca98d212d7c545d5c38de5dd7591L134))

Code simplification:

* Removed unnecessary type assertion for `bootcampId` during the mentor profile creation process. ([src/app/[admin]/organizations/[organizationId]/profile/page.tsxL144-L145](diffhunk://#diff-ecea50bc88354f97ffed3d9825c09379c638ca98d212d7c545d5c38de5dd7591L144-L145))