### PR TITLE
bugfix date range timezone shif

### DIFF
--- a/src/app/[admin]/mentorsDashboard/calendar/page.tsx
+++ b/src/app/[admin]/mentorsDashboard/calendar/page.tsx
@@ -39,6 +39,12 @@ const toDateStr = (date: Date) => {
   return `${year}-${month}-${day}`
 }
 
+const getDateFromISO = (isoString: string): Date => {
+  const datePart = isoString.split('T')[0]
+  const [year, month, day] = datePart.split('-').map(Number)
+  return new Date(year, month - 1, day)
+}
+
 const addDays = (date: Date, days: number) => {
   const result = new Date(date)
   result.setDate(result.getDate() + days)
@@ -435,11 +441,11 @@ export default function CalendarPage() {
   const scrollRef = useRef<HTMLDivElement>(null)
 
   const weekStart = useMemo(
-    () => (apiWeekStart ? new Date(apiWeekStart) : addDays(baseWeekStart, weekOffset * 7)),
+    () => (apiWeekStart ? getDateFromISO(apiWeekStart) : addDays(baseWeekStart, weekOffset * 7)),
     [apiWeekStart, baseWeekStart, weekOffset]
   )
   const weekEnd = useMemo(
-    () => (apiWeekEnd ? new Date(apiWeekEnd) : addDays(weekStart, 6)),
+    () => (apiWeekEnd ? getDateFromISO(apiWeekEnd) : addDays(weekStart, 6)),
     [apiWeekEnd, weekStart]
   )
 
@@ -486,11 +492,11 @@ export default function CalendarPage() {
   const isCurrentWeek = weekOffset === 0
 
   const displayWeekStart = useMemo(
-    () => (apiWeekStart ? new Date(apiWeekStart) : weekStart),
+    () => (apiWeekStart ? getDateFromISO(apiWeekStart) : weekStart),
     [apiWeekStart, weekStart]
   )
   const displayWeekEnd = useMemo(
-    () => (apiWeekEnd ? new Date(apiWeekEnd) : weekEnd),
+    () => (apiWeekEnd ? getDateFromISO(apiWeekEnd) : weekEnd),
     [apiWeekEnd, weekEnd]
   )
 


### PR DESCRIPTION
This pull request refactors how ISO date strings are parsed in the `CalendarPage` component to ensure consistent and reliable date handling. Instead of directly using the JavaScript `Date` constructor with ISO strings, a new utility function is introduced for parsing, and all relevant usages are updated accordingly.

**Date parsing improvements:**

* Added a new utility function `getDateFromISO` to safely parse ISO date strings into `Date` objects, avoiding inconsistencies with the native `Date` constructor. ([src/app/[admin]/mentorsDashboard/calendar/page.tsxR42-R47](diffhunk://#diff-ba49bfed56f965cb7b284a06fe92ecfd441ffb278a8530083a67a26c3b7504a3R42-R47))
* Updated all instances where ISO date strings (`apiWeekStart`, `apiWeekEnd`) are converted to `Date` objects to use the new `getDateFromISO` function, ensuring consistent date handling throughout the `CalendarPage` component. ([src/app/[admin]/mentorsDashboard/calendar/page.tsxL438-R448](diffhunk://#diff-ba49bfed56f965cb7b284a06fe92ecfd441ffb278a8530083a67a26c3b7504a3L438-R448), [src/app/[admin]/mentorsDashboard/calendar/page.tsxL489-R499](diffhunk://#diff-ba49bfed56f965cb7b284a06fe92ecfd441ffb278a8530083a67a26c3b7504a3L489-R499))