### PR TITLE
fix: update work experience logic and college input validation

### DIFF
--- a/src/app/student/_pages/EditProfilePage.tsx
+++ b/src/app/student/_pages/EditProfilePage.tsx
@@ -54,6 +54,12 @@ import type {
   OnboardingStep3 as Step3Type,
   OnboardingStep4 as Step4Type,
 } from '@/lib/profile.types';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import useLearnerProfile from '@/hooks/useLearnerProfile';
 import useUpdateLearnerProfile from '@/hooks/useUpdateLearnerProfile';
 import useLearnerTechnicalSkills from '@/hooks/useLearnerTechnicalSkills';
@@ -257,7 +263,8 @@ export const EditProfilePage: React.FC = () => {
     ...(step3?.academicPerformance || {}),
     ...(editedData?.step3?.academicPerformance || {}),
   };
-
+  const isWorkingStatus =
+  (onboardingData?.step1?.currentStatus ?? step1?.currentStatus) === 'Working';
   const updateAcademicPerformance = (updates: Record<string, any>) => {
     setEditedData((prev: any) => ({
       ...prev,
@@ -308,6 +315,26 @@ export const EditProfilePage: React.FC = () => {
         : '01';
 
     return `${value.year}-${month}-${day}`;
+  };
+
+  const formatWorkExperienceDate = (value?: { month: string; year: string } | string) => {
+    if (!value) {
+      return '';
+    }
+
+    if (typeof value === 'string') {
+      const parsedDate = new Date(value);
+      if (!Number.isNaN(parsedDate.getTime())) {
+        return parsedDate.toLocaleDateString('en-US', {
+          day: '2-digit',
+          month: '2-digit',
+          year: 'numeric',
+        });
+      }
+      return value;
+    }
+
+    return `${value.month} ${value.year}`;
   };
 
   const toMonthNumber = (month?: string) => {
@@ -385,7 +412,10 @@ export const EditProfilePage: React.FC = () => {
       title: experience.role,
       company: experience.companyName,
       startDate: formatMonthYearToDate(experience.startDate),
-      endDate: experience.isCurrentlyWorking ? undefined : formatMonthYearToDate(experience.endDate),
+      isCurrentlyWorking: experience.isCurrentlyWorking,
+      endDate: experience.isCurrentlyWorking
+      ? null
+      : formatMonthYearToDate(experience.endDate),
       description: experience.responsibilities,
     }));
 
@@ -649,9 +679,9 @@ export const EditProfilePage: React.FC = () => {
         id: `api-work-${learnerProfile.id}-${index}`,
         companyName: experience?.company || experience?.companyName || '',
         role: experience?.title || experience?.role || '',
-        startDate: { month: '', year: '' },
-        endDate: { month: '', year: '' },
-        isCurrentlyWorking: false,
+        startDate: experience?.startDate || experience?.start_date || '',
+        endDate: experience?.endDate || experience?.end_date || '',
+        isCurrentlyWorking: Boolean(experience?.isCurrentlyWorking || experience?.is_currently_working),
         workMode: 'Remote' as const,
         responsibilities: experience?.description || '',
       })),
@@ -660,7 +690,8 @@ export const EditProfilePage: React.FC = () => {
         buildCompetitiveProfile('CodeChef', learnerProfile.codechefProfiles || []),
         buildCompetitiveProfile('Codeforces', learnerProfile.codeforcesProfiles || []),
       ],
-      hasInternshipExperience: learnerProfile.hasWorkExperience || false,
+      hasInternshipExperience:
+        (learnerProfile.hasWorkExperience || false) || (learnerProfile.workExperiences?.length || 0) > 0,
     };
 
     const preferredMethods = new Set((learnerProfile.preferredContactMethods || []).map((item) => item.toLowerCase()));
@@ -811,78 +842,72 @@ export const EditProfilePage: React.FC = () => {
       setEditedData({});
     }
   };
-  
+
   const handleSaveAcademic = async () => {
-    if (step1 && step3) {
-      const step1Edits = editedData.step1 || {};
-      const shouldApplyCustomDegree = selectedDegreeValue === 'Other' && (step1Edits.degree === 'Other' || step1Edits.customDegree !== undefined);
-      const shouldApplyCustomBranch = selectedBranchValue === 'Other' && (step1Edits.branch === 'Other' || step1Edits.customBranch !== undefined);
-      const resolvedDegree =
-        shouldApplyCustomDegree
-          ? (String(step1Edits.customDegree || degreeCustomValue || '').trim() || step1.degree)
-          : step1Edits.degree;
-      const resolvedBranch =
-        shouldApplyCustomBranch
-          ? (String(step1Edits.customBranch || branchCustomValue || '').trim() || step1.branch)
-          : step1Edits.branch;
-      const { customDegree, customBranch, ...remainingStep1Edits } = step1Edits;
-      const normalizedStep1Edits = {
-        ...remainingStep1Edits,
-        ...(step1Edits.degree || shouldApplyCustomDegree ? { degree: resolvedDegree } : {}),
-        ...(step1Edits.branch || shouldApplyCustomBranch ? { branch: resolvedBranch } : {}),
-      };
+  // FIX: read fresh from onboardingData at call time, not closed-over step3
+  const currentStep3 = onboardingData?.step3;
 
-      const updatedStep1 = editedData.step1 ? { ...step1, ...normalizedStep1Edits } : step1;
-      const updatedStep3 = editedData.step3 ? { ...step3, ...editedData.step3 } : step3;
+  if (step1 && currentStep3) {
+    const step1Edits = editedData.step1 || {};
+    const shouldApplyCustomDegree =
+      selectedDegreeValue === 'Other' &&
+      (step1Edits.degree === 'Other' || step1Edits.customDegree !== undefined);
+    const shouldApplyCustomBranch =
+      selectedBranchValue === 'Other' &&
+      (step1Edits.branch === 'Other' || step1Edits.customBranch !== undefined);
 
-      const fieldErrors: string[] = [];
-      if (!String(updatedStep1.collegeName || '').trim() && !String(updatedStep1.customCollege || '').trim()) {
-        fieldErrors.push('College selection is required');
-      }
-      if (!String(updatedStep1.degree || '').trim()) {
-        fieldErrors.push('Degree selection is required');
-      }
-      if (!String(updatedStep1.branch || '').trim()) {
-        fieldErrors.push('Branch selection is required');
-      }
-      if (!String(updatedStep1.graduationDate?.month || '').trim() || !String(updatedStep1.graduationDate?.year || '').trim()) {
-        fieldErrors.push('Graduation month and year are required');
-      }
+    const resolvedDegree = shouldApplyCustomDegree
+      ? String(step1Edits.customDegree || degreeCustomValue || '').trim() || step1.degree
+      : step1Edits.degree;
+    const resolvedBranch = shouldApplyCustomBranch
+      ? String(step1Edits.customBranch || branchCustomValue || '').trim() || step1.branch
+      : step1Edits.branch;
 
-      const academic = updatedStep3?.academicPerformance;
-      if (academic?.marksFormat === 'CGPA') {
-        const cgpa = Number(academic?.cgpa);
-        if (!Number.isFinite(cgpa) || cgpa <= 0 || cgpa > 10) {
-          fieldErrors.push('Enter a valid CGPA between 0.0 and 10.0');
-        }
-      }
-      if (academic?.marksFormat === 'Percentage') {
-        const percentage = Number(academic?.percentage);
-        if (!Number.isFinite(percentage) || percentage <= 0 || percentage > 100) {
-          fieldErrors.push('Enter a valid percentage between 0 and 100');
-        }
-      }
+    const updatedStep1: Step1Type = {
+      ...step1,
+      ...(resolvedDegree !== undefined ? { degree: resolvedDegree } : {}),
+      ...(resolvedBranch !== undefined ? { branch: resolvedBranch } : {}),
+      ...(step1Edits.collegeName !== undefined ? { collegeName: step1Edits.collegeName } : {}),
+      ...(step1Edits.customCollege !== undefined ? { customCollege: step1Edits.customCollege } : {}),
+      ...(step1Edits.yearOfStudy !== undefined ? { yearOfStudy: step1Edits.yearOfStudy } : {}),
+      ...(step1Edits.graduationDate !== undefined ? { graduationDate: step1Edits.graduationDate } : {}),
+    };
 
-      if (fieldErrors.length > 0) {
-        showRequiredFieldErrors(fieldErrors);
-        return;
-      }
-
-      if (editedData.step1) {
-        updateStepData(1, updatedStep1);
-      }
-      if (editedData.step3) {
-        updateStepData(3, updatedStep3);
-      }
-
-      const isSaved = await persistProfileChanges(updatedStep1, step2, updatedStep3, step4);
-      if (!isSaved) return;
-
-      showSaveSuccess();
-      setEditingCard(null);
-      setEditedData({});
+    const fieldErrors: string[] = [];
+    if (!String(updatedStep1.collegeName || updatedStep1.customCollege || '').trim()) {
+      fieldErrors.push('College name is required');
     }
-  };
+    if (!String(updatedStep1.degree || '').trim()) {
+      fieldErrors.push('Degree is required');
+    }
+    if (!String(updatedStep1.branch || '').trim()) {
+      fieldErrors.push('Branch is required');
+    }
+    if (fieldErrors.length > 0) {
+      showRequiredFieldErrors(fieldErrors);
+      return;
+    }
+
+    // FIX: build updatedStep3 from currentStep3 (fresh), not stale step3 closure
+    const updatedStep3: Step3Type = {
+      ...currentStep3,
+      ...(editedData.step3 ? editedData.step3 : {}),
+      // Always preserve fresh work experiences — never let editedData overwrite them
+          workExperiences: hasInternship ? currentStep3.workExperiences : [],
+      hasInternshipExperience: hasInternship,
+    };
+
+    updateStepData(1, updatedStep1);
+    updateStepData(3, updatedStep3);
+
+    const isSaved = await persistProfileChanges(updatedStep1, step2, updatedStep3, step4);
+    if (!isSaved) return;
+
+    showSaveSuccess();
+    setEditingCard(null);
+    setEditedData({});
+  }
+};
   
   const handleSaveCompetitive = async () => {
     if (step3) {
@@ -1033,7 +1058,7 @@ export const EditProfilePage: React.FC = () => {
   // Initialize hasInternship when entering work-experience edit mode
   useEffect(() => {
     if (editingCard === 'work-experience') {
-      setHasInternship((step3?.workExperiences?.length ?? 0) > 0);
+      setHasInternship(((step3?.workExperiences?.length ?? 0) > 0) || !!step3?.hasInternshipExperience);
     }
   }, [editingCard, step3?.workExperiences]);
 
@@ -1227,38 +1252,60 @@ export const EditProfilePage: React.FC = () => {
   };
 
   const handleAddOrEditExperience = async (experience: WorkExperience) => {
-    if (!step3) return;
+  // FIX: read fresh step3 at call time
+  const currentStep3 = onboardingData?.step3;
+  if (!step1 || !currentStep3) return;
 
-    const previousExperiences = step3.workExperiences || [];
-    const alreadyExists = previousExperiences.some((item) => item.id === experience.id);
-    const updatedWorkExperiences = alreadyExists
-      ? previousExperiences.map((item) => (item.id === experience.id ? experience : item))
-      : [...previousExperiences, experience];
+  const previousExperiences = currentStep3.workExperiences || [];
 
-    const updatedStep3 = {
-      ...step3,
-      workExperiences: updatedWorkExperiences,
-      hasInternshipExperience: true,
-    };
+  const alreadyExists = previousExperiences.some((item) => item.id === experience.id);
 
-    updateStepData(3, updatedStep3);
-    await persistProfileChanges(step1, step2, updatedStep3, step4);
-    setEditingExperience(undefined);
+  const updatedWorkExperiences = alreadyExists
+    ? previousExperiences.map((item) => (item.id === experience.id ? experience : item))
+    : [...previousExperiences, experience];
+
+  const updatedStep3: Step3Type = {
+    ...currentStep3,
+    workExperiences: updatedWorkExperiences,
+    hasInternshipExperience: true,
   };
+
+  // FIX: keep local hasInternship state in sync so Save Changes doesn't reset it
+  setHasInternship(true);
+
+  updateStepData(3, updatedStep3);
+
+  const isSaved = await persistProfileChanges(step1, step2, updatedStep3, step4);
+  if (!isSaved) return;
+
+  showSaveSuccess();
+};
 
   const handleDeleteExperience = async (experienceId: string) => {
-    if (!step3) return;
+  // FIX: read fresh step3 at call time
+  const currentStep3 = onboardingData?.step3;
+  if (!step1 || !currentStep3) return;
 
-    const updatedWorkExperiences = (step3.workExperiences || []).filter((item) => item.id !== experienceId);
-    const updatedStep3 = {
-      ...step3,
-      workExperiences: updatedWorkExperiences,
-      hasInternshipExperience: updatedWorkExperiences.length > 0,
-    };
+  const updatedWorkExperiences = (currentStep3.workExperiences || []).filter(
+    (item) => item.id !== experienceId
+  );
 
-    updateStepData(3, updatedStep3);
-    await persistProfileChanges(step1, step2, updatedStep3, step4);
+  const updatedStep3: Step3Type = {
+    ...currentStep3,
+    workExperiences: updatedWorkExperiences,
+    hasInternshipExperience: updatedWorkExperiences.length > 0,
   };
+
+  // Keep local state in sync
+  setHasInternship(updatedWorkExperiences.length > 0);
+
+  updateStepData(3, updatedStep3);
+
+  const isSaved = await persistProfileChanges(step1, step2, updatedStep3, step4);
+  if (!isSaved) return;
+
+  showSaveSuccess();
+};
 
   const handleVerifyProfile = async (platform: string) => {
     setVerifyingPlatform(platform);
@@ -2407,7 +2454,7 @@ export const EditProfilePage: React.FC = () => {
                                     }}
                                     className="flex-1 bg-muted/30"
                                   />
-                                  <button
+                                  {/* <button
                                     type="button"
                                     className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
                                       mergedAcademicPerformance.marksFormat === 'CGPA'
@@ -2417,7 +2464,7 @@ export const EditProfilePage: React.FC = () => {
                                     onClick={() => updateAcademicPerformance({ marksFormat: 'CGPA' })}
                                   >
                                     CGPA
-                                  </button>
+                                  </button> */}
                                   <button
                                     type="button"
                                     className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
@@ -2483,7 +2530,7 @@ export const EditProfilePage: React.FC = () => {
                                       }}
                                       className="flex-1 bg-muted/30"
                                     />
-                                    <button
+                                    {/* <button
                                       type="button"
                                       className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
                                         (mergedAcademicPerformance.class12Format || 'Percentage') === 'CGPA'
@@ -2493,7 +2540,7 @@ export const EditProfilePage: React.FC = () => {
                                       onClick={() => updateAcademicPerformance({ class12Format: 'CGPA' })}
                                     >
                                       CGPA
-                                    </button>
+                                    </button> */}
                                     <button
                                       type="button"
                                       className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
@@ -2560,7 +2607,7 @@ export const EditProfilePage: React.FC = () => {
                                       }}
                                       className="flex-1 bg-muted/30"
                                     />
-                                    <button
+                                    {/* <button
                                       type="button"
                                       className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
                                         (mergedAcademicPerformance.class10Format || 'Percentage') === 'CGPA'
@@ -2570,7 +2617,7 @@ export const EditProfilePage: React.FC = () => {
                                       onClick={() => updateAcademicPerformance({ class10Format: 'CGPA' })}
                                     >
                                       CGPA
-                                    </button>
+                                    </button> */}
                                     <button
                                       type="button"
                                       className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
@@ -2621,7 +2668,15 @@ export const EditProfilePage: React.FC = () => {
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => setEditingCard('work-experience')}
+                    // onClick={() => setEditingCard('work-experience')}
+                    onClick={() => {
+                     const currentStep3 = onboardingData?.step3;
+                     setEditingCard('work-experience');
+                     setHasInternship(
+                     Boolean(currentStep3?.hasInternshipExperience) ||
+                     (currentStep3?.workExperiences?.length ?? 0) > 0
+                     );
+                    }}
                     className="gap-2"
                   >
                     <Edit2 className="w-4 h-4" />
@@ -2632,17 +2687,18 @@ export const EditProfilePage: React.FC = () => {
               <CardContent className="pb-6 pt-6">
                 {editingCard !== 'work-experience' ? (
                   <>
-                    {step3?.hasInternshipExperience ? (
+                    {((step3?.workExperiences?.length ?? 0) > 0 || step3?.hasInternshipExperience) ? (
                       (step3?.workExperiences && step3.workExperiences.length > 0) ? (
                         <div className="space-y-3">
                           {step3.workExperiences.map((exp) => (
+                            
                             <Card key={exp.id} className="bg-muted/30 border-border/30">
                               <CardContent className="p-4">
-                                <h4 className="font-medium">{exp.role}</h4>
+                                <h4 className="font-medium text-sm">{exp.role}</h4>
                                 <p className="text-sm text-muted-foreground">{exp.companyName}</p>
                                 <p className="text-xs text-muted-foreground mt-1">
-                                  {exp.startDate.month} {exp.startDate.year} →{' '}
-                                  {exp.isCurrentlyWorking ? 'Present' : `${exp.endDate?.month} ${exp.endDate?.year}`}
+                                  {formatWorkExperienceDate(exp.startDate)} →{' '}
+                                  {exp.isCurrentlyWorking ? 'Present' : formatWorkExperienceDate(exp.endDate)}
                                 </p>
                                 <div className="flex items-center gap-2 mt-2">
                                   <Badge variant="outline" className="text-xs">
@@ -2679,24 +2735,44 @@ export const EditProfilePage: React.FC = () => {
                         {/* Have Internship Toggle */}
                         <div className="space-y-4">
                           <Label className="font-medium">Have you done any internships or jobs?</Label>
-                          <div className="grid grid-cols-2 gap-4">
-                            <Button
-                              type="button"
-                              variant={!hasInternship ? 'default' : 'outline'}
-                              onClick={() => setHasInternship(false)}
-                              className="h-10"
-                            >
-                              No, I&apos;m a Fresher
-                            </Button>
-                            <Button
-                              type="button"
-                              variant={hasInternship ? 'default' : 'outline'}
-                              onClick={() => setHasInternship(true)}
-                              className="h-10"
-                            >
-                              Yes, I have experience
-                            </Button>
-                          </div>
+                          <div className="space-y-2">
+                             <div className="grid grid-cols-2 gap-4">
+                                <TooltipProvider>
+                                  <Tooltip>
+                                  <TooltipTrigger asChild>
+                                   <span className={isWorkingStatus ? 'cursor-not-allowed' : 'inline-block w-full'}>
+                                     <Button
+                                       type="button"
+                                        variant={!hasInternship ? 'default' : 'outline'}
+                                        disabled={isWorkingStatus}
+                                         onClick={() => {
+                                         if (isWorkingStatus) return;
+                                        setHasInternship(false);
+                                        }}
+                                        className="h-10 w-full disabled:cursor-not-allowed disabled:opacity-50"
+                                        >
+                                        No, I&apos;m a Fresher
+                                       </Button>
+                                        </span>
+                                        </TooltipTrigger>
+                                          {isWorkingStatus && (
+                                           <TooltipContent side="top" align="center">
+                                             Your profile status is set to Working, so the Fresher option is disabled.
+                                             </TooltipContent>
+                                           )}
+                                        </Tooltip>
+                                        </TooltipProvider>
+
+                                       <Button
+                                          type="button"
+                                         variant={hasInternship ? 'default' : 'outline'}
+                                          onClick={() => setHasInternship(true)}
+                                        className="h-10"
+                                           >
+                                           Yes, I have experience
+                                      </Button>
+                                    </div>
+                              </div>
                         </div>
 
                         {/* Show Experience Form only if hasInternship is true */}
@@ -2715,26 +2791,27 @@ export const EditProfilePage: React.FC = () => {
                             />
 
                             {/* Existing Work Experiences */}
-                            {step3?.workExperiences && step3.workExperiences.length > 0 && (
-                              <div className="divide-y divide-border">
-                                {step3.workExperiences.map((experience) => (
-                                  <WorkExperienceCard
-                                    key={experience.id}
-                                    experience={experience}
-                                    onEdit={(exp) => {
-                                      setEditingExperience(exp);
-                                      setIsExperienceModalOpen(true);
-                                    }}
-                                    onDelete={handleDeleteExperience}
-                                  />
-                                ))}
-                              </div>
+                          {onboardingData?.step3?.workExperiences &&
+                          onboardingData.step3.workExperiences.length > 0 && (
+                           <div className="divide-y divide-border">
+                            {onboardingData.step3.workExperiences.map((experience) => (
+                              <WorkExperienceCard
+                               key={experience.id}
+                               experience={experience}
+                               onEdit={(exp) => {
+                               setEditingExperience(exp);
+                               setIsExperienceModalOpen(true);
+                                }}
+                              onDelete={handleDeleteExperience}
+                           />
+                              ))}
+                            </div>
                             )}
                             
                             {/* Add New Experience Button */}
                             <div className="border-2 border-dashed border-border rounded-lg p-4 text-center">
                               <p className="text-sm text-muted-foreground mb-3">
-                                {step3?.workExperiences && step3.workExperiences.length > 0
+                                {onboardingData?.step3?.workExperiences && onboardingData.step3.workExperiences.length > 0
                                   ? 'Showcase more of your professional journey'
                                   : 'Build your professional profile'}
                               </p>
@@ -2753,6 +2830,14 @@ export const EditProfilePage: React.FC = () => {
                             </div>
                           </>
                         )}
+                        {!hasInternship && (
+                          <div className="text-center py-6">
+                           <GraduationCap className="w-10 h-10 text-muted-foreground mx-auto mb-2" />
+                           <p className="text-sm text-muted-foreground">
+                             No experience added — you will be saved as a fresher.
+                           </p>
+                           </div>
+                         )}
                         
                         {/* Save Button */}
                         <div className="flex justify-end gap-2 pt-4">

--- a/src/app/student/_pages/ProfilePage.tsx
+++ b/src/app/student/_pages/ProfilePage.tsx
@@ -256,7 +256,10 @@ export const OnboardingPage: React.FC<OnboardingPageProps> = ({ userEmail = '', 
       title: experience.role,
       company: experience.companyName,
       startDate: formatMonthYearToDate(experience.startDate),
-      endDate: experience.isCurrentlyWorking ? undefined : formatMonthYearToDate(experience.endDate),
+     isCurrentlyWorking: experience.isCurrentlyWorking,
+      endDate: experience.isCurrentlyWorking
+      ? null
+      : formatMonthYearToDate(experience.endDate),
       description: experience.responsibilities,
     }));
 
@@ -462,7 +465,7 @@ export const OnboardingPage: React.FC<OnboardingPageProps> = ({ userEmail = '', 
           ? String(onboardingData.step1?.graduationDate?.year)
           : profileStep1.graduationDate.year,
       },
-      currentStatus: onboardingData.step1?.currentStatus || profileStep1.currentStatus,
+      currentStatus: profileStep1.currentStatus || onboardingData.step1?.currentStatus || 'Learning',
     };
 
     const profileStep2: Step2Type = {
@@ -512,9 +515,9 @@ export const OnboardingPage: React.FC<OnboardingPageProps> = ({ userEmail = '', 
         id: `api-work-${learnerProfile.id}-${index}`,
         companyName: experience?.company || experience?.companyName || '',
         role: experience?.title || experience?.role || '',
-        startDate: { month: '', year: '' },
-        endDate: { month: '', year: '' },
-        isCurrentlyWorking: false,
+        startDate: experience?.startDate || experience?.start_date || '',
+        endDate: experience?.endDate || experience?.end_date || '',
+        isCurrentlyWorking: Boolean(experience?.isCurrentlyWorking || experience?.is_currently_working),
         workMode: 'Remote',
         responsibilities: experience?.description || '',
       })),
@@ -523,8 +526,15 @@ export const OnboardingPage: React.FC<OnboardingPageProps> = ({ userEmail = '', 
         buildCompetitiveProfile('CodeChef', learnerProfile.codechefProfiles as any[]),
         buildCompetitiveProfile('Codeforces', learnerProfile.codeforcesProfiles as any[]),
       ],
-      hasInternshipExperience: learnerProfile.hasWorkExperience || false,
+      hasInternshipExperience:
+        (learnerProfile.hasWorkExperience || false) || (learnerProfile.workExperiences?.length || 0) > 0,
     };
+
+    const hasSavedWorkExperience =
+      (onboardingData.step3?.workExperiences?.length || 0) > 0 ||
+      (profileStep3.workExperiences?.length || 0) > 0 ||
+      onboardingData.step3?.hasInternshipExperience ||
+      profileStep3.hasInternshipExperience;
 
     const mergedStep3: Step3Type = {
       academicPerformance: onboardingData.step3?.academicPerformance || profileStep3.academicPerformance,
@@ -537,7 +547,7 @@ export const OnboardingPage: React.FC<OnboardingPageProps> = ({ userEmail = '', 
           ? onboardingData.step3!.competitiveProfiles
           : profileStep3.competitiveProfiles,
       hasInternshipExperience:
-        onboardingData.step3?.hasInternshipExperience ?? profileStep3.hasInternshipExperience,
+        hasSavedWorkExperience,
     };
 
     const preferredMethods = new Set(

--- a/src/app/student/profile/ProfileStep1.tsx
+++ b/src/app/student/profile/ProfileStep1.tsx
@@ -196,7 +196,7 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
     phoneNumber: data.phoneNumber?.trim() || '',
     linkedin: data.linkedin?.trim() || '',
     collegeName: data.collegeName?.trim() || '',
-    customCollege: data.customCollege?.trim() || '',
+    customCollege: data.customCollege ?? '',
     degree: data.degree?.trim() || '',
     branch: data.branch?.trim() || '',
     yearOfStudy: (data.yearOfStudy as Step1Type['yearOfStudy']) || '1st',

--- a/src/app/student/profile/ProfileStep3.tsx
+++ b/src/app/student/profile/ProfileStep3.tsx
@@ -130,7 +130,8 @@ export const ProfileStep3Component: React.FC<ProfileStep3Props> = ({
   onBack,
   onFieldChange,
 }) => {
-  const [hasInternship, setHasInternship] = useState(initialData?.hasInternshipExperience ?? false);
+  const hasInitialWorkExperience = (initialData?.workExperiences?.length ?? 0) > 0 || initialData?.hasInternshipExperience || false;
+  const [hasInternship, setHasInternship] = useState(hasInitialWorkExperience);
   const hasInternshipEditedRef = useRef<boolean>(false);
   const [academicData, setAcademicData] = useState<AcademicPerformance>(
     initialData?.academicPerformance || { marksFormat: 'CGPA' }
@@ -193,13 +194,14 @@ export const ProfileStep3Component: React.FC<ProfileStep3Props> = ({
     if (hasInternshipEditedRef.current) return;
 
     const status = step1Data.currentStatus;
-    // Consider 'Working' as having work experience; other statuses treated as fresher by default
-    if (status === 'Working') {
+    const hasExistingWorkExperience = hasInitialWorkExperience || workExperiences.length > 0;
+
+    if (hasExistingWorkExperience || status === 'Working') {
       setHasInternship(true);
     } else {
       setHasInternship(false);
     }
-  }, [step1Data?.currentStatus]);
+  }, [step1Data?.currentStatus, workExperiences.length, hasInitialWorkExperience]);
   
   // Auto-save form data on change
   useEffect(() => {
@@ -459,7 +461,7 @@ export const ProfileStep3Component: React.FC<ProfileStep3Props> = ({
                         }}
                         className={`flex-1 mt-0 ${errors.cgpa || errors.percentage ? 'border-destructive' : ''}`}
                       />
-                      <button
+                      {/* <button
                         type="button"
                         onClick={() => {
                           const nextFormat: 'CGPA' | 'Percentage' = 'CGPA';
@@ -484,7 +486,7 @@ export const ProfileStep3Component: React.FC<ProfileStep3Props> = ({
                         }`}
                       >
                         CGPA
-                      </button>
+                      </button> */}
                       <button
                         type="button"
                         onClick={() => {
@@ -621,7 +623,7 @@ export const ProfileStep3Component: React.FC<ProfileStep3Props> = ({
                         }}
                         className={`flex-1 mt-0 ${errors.class12Percentage ? 'border-destructive' : ''}`}
                       />
-                      <button
+                      {/* <button
                         type="button"
                         onClick={() => {
                           const nextFormat: 'CGPA' | 'Percentage' = 'CGPA';
@@ -644,7 +646,7 @@ export const ProfileStep3Component: React.FC<ProfileStep3Props> = ({
                         }`}
                       >
                         CGPA
-                      </button>
+                      </button> */}
                       <button
                         type="button"
                         onClick={() => {
@@ -779,7 +781,7 @@ export const ProfileStep3Component: React.FC<ProfileStep3Props> = ({
                         }}
                         className={`flex-1 mt-0 ${errors.class10Marks ? 'border-destructive' : ''}`}
                       />
-                      <button
+                      {/* <button
                         type="button"
                         onClick={() => {
                           const nextFormat: 'CGPA' | 'Percentage' = 'CGPA';
@@ -802,7 +804,7 @@ export const ProfileStep3Component: React.FC<ProfileStep3Props> = ({
                         }`}
                       >
                         CGPA
-                      </button>
+                      </button> */}
                       <button
                         type="button"
                         onClick={() => {

--- a/src/app/student/profile/WorkExperienceComponents.tsx
+++ b/src/app/student/profile/WorkExperienceComponents.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -18,6 +18,53 @@ import { AlertCircle, Calendar, X, Briefcase } from 'lucide-react';
 import type { WorkExperience } from '@/lib/profile.types';
 import { MONTHS, TECH_STACK, SKILLS_BY_CATEGORY } from '@/lib/profile.mockData';
 import { useLearnerTechnicalSkills } from '@/hooks/useLearnerTechnicalSkills';
+import { format } from 'date-fns';
+
+const formatDateForInput = (dateValue?: WorkExperience['startDate']) => {
+  if (!dateValue) {
+    return '';
+  }
+
+  if (typeof dateValue === 'string') {
+    return dateValue;
+  }
+
+  const year = String(dateValue.year);
+  const month = String(Number(dateValue.month)).padStart(2, '0');
+  return `${year}-${month}-01`;
+};
+
+const getTodayInputValue = () => {
+  const today = new Date();
+  return today.toISOString().split('T')[0];
+};
+
+const isEarlierThan = (leftDate?: string, rightDate?: string) => {
+  if (!leftDate || !rightDate) {
+    return false;
+  }
+
+  return leftDate < rightDate;
+};
+
+const formatExperienceDate = (dateValue?: WorkExperience['startDate']) => {
+  if (!dateValue) {
+    return 'Select date';
+  }
+
+  if (typeof dateValue === 'string') {
+    const parsedDate = new Date(dateValue);
+    return Number.isNaN(parsedDate.getTime()) ? dateValue : format(parsedDate, 'dd-MM-yyyy');
+  }
+
+  if (!dateValue.year || !dateValue.month) {
+    return 'Select date';
+  }
+
+  const monthIndex = Number(dateValue.month) - 1;
+  const normalizedDate = new Date(Number(dateValue.year), monthIndex, 1);
+  return format(normalizedDate, 'dd-MM-yyyy');
+};
 
 export const WorkExperienceModal: React.FC<{
   isOpen: boolean;
@@ -30,7 +77,7 @@ export const WorkExperienceModal: React.FC<{
       id: Date.now().toString(),
       companyName: '',
       role: '',
-      startDate: { month: '', year: '' },
+      startDate: '',
       endDate: undefined,
       isCurrentlyWorking: false,
       workMode: 'Remote',
@@ -41,6 +88,10 @@ export const WorkExperienceModal: React.FC<{
   );
   const [errors, setErrors] = useState<Record<string, string>>({});
   const { technicalSkills, loading: isLoadingTechStack } = useLearnerTechnicalSkills();
+  const [startDateInputValue, setStartDateInputValue] = useState(formatDateForInput(initialExperience?.startDate) || '');
+  const [endDateInputValue, setEndDateInputValue] = useState(formatDateForInput(initialExperience?.endDate) || '');
+  const startDateInputRef = useRef<HTMLInputElement>(null);
+  const endDateInputRef = useRef<HTMLInputElement>(null);
 
   const allTechOptions = technicalSkills.length > 0
     ? technicalSkills.map((s) => s.name)
@@ -49,15 +100,43 @@ export const WorkExperienceModal: React.FC<{
   useEffect(() => {
     if (initialExperience) {
       setFormData(initialExperience);
+      setStartDateInputValue(formatDateForInput(initialExperience.startDate) || '');
+      setEndDateInputValue(formatDateForInput(initialExperience.endDate) || '');
     }
   }, [initialExperience]);
+
+  useEffect(() => {
+    if (isOpen) {
+      if (initialExperience) {
+        setFormData(initialExperience);
+        setStartDateInputValue(formatDateForInput(initialExperience.startDate) || '');
+        setEndDateInputValue(formatDateForInput(initialExperience.endDate) || '');
+      } else {
+        setFormData({
+          id: Date.now().toString(),
+          companyName: '',
+          role: '',
+          startDate: '',
+          endDate: undefined,
+          isCurrentlyWorking: false,
+          workMode: 'Remote',
+          city: '',
+          responsibilities: '',
+          technologiesUsed: [],
+        });
+        setStartDateInputValue('');
+        setEndDateInputValue('');
+      }
+      setErrors({});
+    }
+  }, [isOpen, initialExperience]);
 
   const validateForm = () => {
     const newErrors: Record<string, string> = {};
     if (!formData.companyName.trim()) newErrors.companyName = 'Company name is required';
     if (!formData.role.trim()) newErrors.role = 'Role/Title is required';
-    if (!formData.startDate.month || !formData.startDate.year) newErrors.startDate = 'Start date is required';
-    if (!formData.isCurrentlyWorking && (!formData.endDate?.month || !formData.endDate?.year)) {
+    if (!formData.startDate) newErrors.startDate = 'Start date is required';
+    if (!formData.isCurrentlyWorking && !formData.endDate) {
       newErrors.endDate = 'End date is required';
     }
     if (formData.workMode === 'On-site' && !formData.city?.trim()) {
@@ -78,13 +157,18 @@ export const WorkExperienceModal: React.FC<{
 
   const handleSubmit = () => {
     if (validateForm()) {
-      onSave(formData);
+      const normalizedExperience: WorkExperience = {
+        ...formData,
+        endDate: formData.isCurrentlyWorking ? undefined : formData.endDate,
+      };
+
+      onSave(normalizedExperience);
       onOpenChange(false);
       setFormData({
         id: Date.now().toString(),
         companyName: '',
         role: '',
-        startDate: { month: '', year: '' },
+        startDate: '',
         endDate: undefined,
         isCurrentlyWorking: false,
         workMode: 'Remote',
@@ -92,6 +176,8 @@ export const WorkExperienceModal: React.FC<{
         responsibilities: '',
         technologiesUsed: [],
       });
+      setStartDateInputValue('');
+      setEndDateInputValue('');
     }
   };
 
@@ -152,14 +238,61 @@ export const WorkExperienceModal: React.FC<{
               <div className="relative">
                 <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
                 <Input
+                  ref={startDateInputRef}
                   id="startDate"
-                  type="month"
-                  value={formData.startDate.year && formData.startDate.month ? `${formData.startDate.year}-${formData.startDate.month.padStart(2, '0')}` : ''}
+                  type="date"
+                  value={startDateInputValue}
+                  max={getTodayInputValue()}
+                  onClick={() => startDateInputRef.current?.showPicker?.()}
                   onChange={(e) => {
-                    const [year, month] = e.target.value.split('-');
-                    setFormData((prev) => ({ ...prev, startDate: { year, month: parseInt(month).toString() } }));
+                    const dateValue = e.target.value;
+                    setStartDateInputValue(dateValue);
+
+                    if (dateValue && isEarlierThan(getTodayInputValue(), dateValue)) {
+                      setErrors((prev) => ({
+                        ...prev,
+                        startDate: 'Start date cannot be in the future',
+                      }));
+                      return;
+                    }
+
+                    if (dateValue) {
+                      const currentEndDate = endDateInputValue;
+                      if (currentEndDate && isEarlierThan(currentEndDate, dateValue)) {
+                        setFormData((prev) => ({
+                          ...prev,
+                          startDate: dateValue,
+                          endDate: undefined,
+                        }));
+                        setEndDateInputValue('');
+                        setErrors((prev) => {
+                          const next = { ...prev };
+                          delete next.endDate;
+                          delete next.startDate;
+                          return next;
+                        });
+                        return;
+                      }
+
+                      setFormData((prev) => ({
+                        ...prev,
+                        startDate: dateValue,
+                      }));
+                      setErrors((prev) => {
+                        const next = { ...prev };
+                        delete next.startDate;
+                        return next;
+                      });
+                    } else {
+                      setFormData((prev) => ({ ...prev, startDate: '' }));
+                      setErrors((prev) => {
+                        const next = { ...prev };
+                        delete next.startDate;
+                        return next;
+                      });
+                    }
                   }}
-                  className={`pl-10 [&::-webkit-calendar-picker-indicator]:hidden ${errors.startDate ? 'border-destructive' : ''}`}
+                  className={`pl-10 appearance-none [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:opacity-0 ${errors.startDate ? 'border-destructive' : ''}`}
                 />
               </div>
               {errors.startDate && (
@@ -176,15 +309,56 @@ export const WorkExperienceModal: React.FC<{
               <div className="relative">
                 <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
                 <Input
+                  ref={endDateInputRef}
                   id="endDate"
-                  type="month"
+                  type="date"
                   disabled={formData.isCurrentlyWorking}
-                  value={formData.endDate?.year && formData.endDate?.month ? `${formData.endDate.year}-${formData.endDate.month.padStart(2, '0')}` : ''}
+                  value={endDateInputValue}
+                  max={getTodayInputValue()}
+                  min={startDateInputValue || undefined}
+                  onClick={() => endDateInputRef.current?.showPicker?.()}
                   onChange={(e) => {
-                    const [year, month] = e.target.value.split('-');
-                    setFormData((prev) => ({ ...prev, endDate: { year, month: parseInt(month).toString() } }));
+                    const dateValue = e.target.value;
+                    setEndDateInputValue(dateValue);
+                    const startDateValue = startDateInputValue;
+
+                    if (dateValue && isEarlierThan(getTodayInputValue(), dateValue)) {
+                      setErrors((prev) => ({
+                        ...prev,
+                        endDate: 'End date cannot be in the future',
+                      }));
+                      return;
+                    }
+
+                    if (startDateValue && isEarlierThan(dateValue, startDateValue)) {
+                      setErrors((prev) => ({
+                        ...prev,
+                        endDate: 'End date must be the same as or later than the start date',
+                      }));
+                      return;
+                    }
+
+                    if (dateValue) {
+                      setFormData((prev) => ({
+                        ...prev,
+                        endDate: dateValue,
+                      }));
+
+                      setErrors((prev) => {
+                        const next = { ...prev };
+                        delete next.endDate;
+                        return next;
+                      });
+                    } else {
+                      setFormData((prev) => ({ ...prev, endDate: undefined }));
+                      setErrors((prev) => {
+                        const next = { ...prev };
+                        delete next.endDate;
+                        return next;
+                      });
+                    }
                   }}
-                  className={`pl-10 [&::-webkit-calendar-picker-indicator]:hidden ${errors.endDate ? 'border-destructive' : ''}`}
+                  className={`pl-10 appearance-none [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:opacity-0 ${errors.endDate ? 'border-destructive' : ''}`}
                 />
               </div>
               {errors.endDate && (
@@ -202,11 +376,22 @@ export const WorkExperienceModal: React.FC<{
               id="currentlyWorking"
               checked={formData.isCurrentlyWorking}
               onCheckedChange={(checked) => {
+                const isCurrentlyWorking = checked as boolean;
+
+               console.log("Checkbox changed:", isCurrentlyWorking);
                 setFormData((prev) => ({
                   ...prev,
-                  isCurrentlyWorking: checked as boolean,
-                  endDate: checked ? undefined : prev.endDate,
+                  isCurrentlyWorking,
+                  endDate: isCurrentlyWorking ? undefined : prev.endDate,
                 }));
+                if (isCurrentlyWorking) {
+                  setEndDateInputValue('');
+                  setErrors((prev) => {
+                    const next = { ...prev };
+                    delete next.endDate;
+                    return next;
+                  });
+                }
               }}
             />
             <Label htmlFor="currentlyWorking" className="font-medium cursor-pointer mt-5">
@@ -362,10 +547,10 @@ export const WorkExperienceCard: React.FC<{
 
         <p className="text-sm font-medium text-foreground">{experience.role}</p>
         <p className="text-sm text-muted-foreground">
-          {MONTHS[parseInt(experience.startDate.month) - 1]} {experience.startDate.year} -{' '}
+          {formatExperienceDate(experience.startDate)} -{' '}
           {experience.isCurrentlyWorking
             ? 'Present'
-            : `${MONTHS[parseInt(experience.endDate!.month) - 1]} ${experience.endDate!.year}`}
+            : formatExperienceDate(experience.endDate)}
           {experience.workMode === 'On-site' && experience.city && ` • ${experience.city}`}
         </p>
 

--- a/src/lib/profile.types.ts
+++ b/src/lib/profile.types.ts
@@ -54,8 +54,8 @@ export interface WorkExperience {
   id: string;
   companyName: string;
   role: string;
-  startDate: { month: string; year: string };
-  endDate?: { month: string; year: string };
+  startDate: { month: string; year: string } | string;
+  endDate?: { month: string; year: string } | string;
   isCurrentlyWorking: boolean;
   workMode: 'Remote' | 'On-site';
   city?: string;


### PR DESCRIPTION
Student Learner Profile : 

-  Fixed the issue where users could not enter spaces while typing a college name.
- Updated the work experience payload to send `isCurrentlyWorking`; when a student selects "I am currently working here", the end date is sent as empty.
- Added a date picker/calendar for the Work Experience section to allow proper date selection.
- Removed the CGPA option and now displays only percentage scores in the Academic Performance section.
