### PR TITLE
implement leaderboard with top 5 rankings and self position

### DIFF
--- a/src/app/[admin]/organizations/[organizationId]/courses/[courseId]/(courseTabs)/settings/page.tsx
+++ b/src/app/[admin]/organizations/[organizationId]/courses/[courseId]/(courseTabs)/settings/page.tsx
@@ -28,6 +28,7 @@ const Page = ({ params }: { params: PageProps }) => {
     const { user } = getUser()
     const userRole = user?.rolesList?.[0]?.toLowerCase() || ''
     const isSuperAdmin = userRole === 'super_admin'
+    const isAdmin = userRole === 'admin'
     const orgId = Number(organizationId) || user?.orgId; 
 
     // Use the custom hooks
@@ -182,6 +183,16 @@ const Page = ({ params }: { params: PageProps }) => {
                             </span>
                         </h2>
                     )}
+                    {!isSuperAdmin && !isAdmin && (
+                        <h2 className="text-base font-medium text-foreground">
+                            Leaderboard -{' '}
+                            <span className="font-light">
+                                {localSettings.leaderboardEnabled
+                                    ? 'Enabled'
+                                    : 'Disabled'}
+                            </span>
+                        </h2>
+                    )}
                     <RadioGroup
                         value={localSettings.type.toLowerCase()}
                         onValueChange={(value) =>
@@ -254,37 +265,40 @@ const Page = ({ params }: { params: PageProps }) => {
                         </div>
                     </div>
                 </div>
-
-                <div className="mt-4 pt-2 border-t border-border">
-                    <div className="flex items-center justify-between">
-                        <div>
-                            <h2 className="text-base font-medium text-foreground mb-1">
-                                Leaderboard
-                            </h2>
-                            <p className="text-sm text-muted-foreground">
-                                If enabled, leaderboard data will be visible in learner, leader views.
-                            </p>
-                        </div>
-                        <div className="flex flex-col justify-left items-start">
-                            <div
-                                className={`relative w-11 h-6 rounded-full bg-gray-300 p-0.5 cursor-pointer ${
-                                    localSettings.leaderboardEnabled
-                                        ? 'bg-primary'
-                                        : ''
-                                }`}
-                                onClick={handleLeaderboardToggle}
-                            >
+                
+                {/* Leaderboard Toggle Switch */}
+                {(isSuperAdmin || isAdmin) && (
+                    <div className="mt-4 pt-2 border-t border-border">
+                        <div className="flex items-center justify-between">
+                            <div>
+                                <h2 className="text-base font-medium text-foreground mb-1">
+                                    Leaderboard
+                                </h2>
+                                <p className="text-sm text-muted-foreground">
+                                    If enabled, leaderboard data will be visible in learner, leader views.
+                                </p>
+                            </div>
+                            <div className="flex flex-col justify-left items-start">
                                 <div
-                                    className={`absolute ml-0.5 left-0 w-5 h-5 bg-white rounded-full shadow-md transform transition-transform ${
+                                    className={`relative w-11 h-6 rounded-full bg-gray-300 p-0.5 cursor-pointer ${
                                         localSettings.leaderboardEnabled
-                                            ? 'translate-x-full'
+                                            ? 'bg-primary'
                                             : ''
                                     }`}
-                                />
+                                    onClick={handleLeaderboardToggle}
+                                >
+                                    <div
+                                        className={`absolute ml-0.5 left-0 w-5 h-5 bg-white rounded-full shadow-md transform transition-transform ${
+                                            localSettings.leaderboardEnabled
+                                                ? 'translate-x-full'
+                                                : ''
+                                        }`}
+                                    />
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
+                )}
 
                 {/* One-on-One Sessions Toggle Switch */}
                 {isSuperAdmin && (

--- a/src/app/[admin]/organizations/[organizationId]/courses/[courseId]/(courseTabs)/settings/page.tsx
+++ b/src/app/[admin]/organizations/[organizationId]/courses/[courseId]/(courseTabs)/settings/page.tsx
@@ -45,6 +45,7 @@ const Page = ({ params }: { params: PageProps }) => {
         type: '',
         isModuleLocked: false,
         mentorshipEnabled: false,
+        leaderboardEnabled: false,
     })
     const [isDeleteModalOpen, setDeleteModalOpen] = useState(false)
     const [isSaving, setIsSaving] = useState(false)
@@ -57,6 +58,7 @@ const Page = ({ params }: { params: PageProps }) => {
                 type: bootcampSettings.type,
                 isModuleLocked: bootcampSettings.isModuleLocked,
                 mentorshipEnabled: bootcampSettings.mentorshipEnabled,
+                leaderboardEnabled: bootcampSettings.leaderboardEnabled,
             })
         }
     }, [bootcampSettings])
@@ -79,6 +81,13 @@ const Page = ({ params }: { params: PageProps }) => {
         setLocalSettings((prev) => ({
             ...prev,
             mentorshipEnabled: !prev.mentorshipEnabled,
+        }))
+    }
+
+    const handleLeaderboardToggle = () => {
+        setLocalSettings((prev) => ({
+            ...prev,
+            leaderboardEnabled: !prev.leaderboardEnabled,
         }))
     }
 
@@ -237,6 +246,37 @@ const Page = ({ params }: { params: PageProps }) => {
                                 <div
                                     className={`absolute ml-0.5 left-0 w-5 h-5 bg-white rounded-full shadow-md transform transition-transform ${
                                         localSettings.isModuleLocked
+                                            ? 'translate-x-full'
+                                            : ''
+                                    }`}
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="mt-4 pt-2 border-t border-border">
+                    <div className="flex items-center justify-between">
+                        <div>
+                            <h2 className="text-base font-medium text-foreground mb-1">
+                                Leaderboard
+                            </h2>
+                            <p className="text-sm text-muted-foreground">
+                                If enabled, leaderboard data will be visible in learner, leader views.
+                            </p>
+                        </div>
+                        <div className="flex flex-col justify-left items-start">
+                            <div
+                                className={`relative w-11 h-6 rounded-full bg-gray-300 p-0.5 cursor-pointer ${
+                                    localSettings.leaderboardEnabled
+                                        ? 'bg-primary'
+                                        : ''
+                                }`}
+                                onClick={handleLeaderboardToggle}
+                            >
+                                <div
+                                    className={`absolute ml-0.5 left-0 w-5 h-5 bg-white rounded-full shadow-md transform transition-transform ${
+                                        localSettings.leaderboardEnabled
                                             ? 'translate-x-full'
                                             : ''
                                     }`}

--- a/src/app/student/_pages/CourseDashboardPage.tsx
+++ b/src/app/student/_pages/CourseDashboardPage.tsx
@@ -31,6 +31,8 @@ import { ModuleContentCounts, TopicItem } from '@/app/student/_pages/pageStudent
 import { formatUpcomingItem } from "@/utils/students"
 import { CourseDashboardSkeleton, CourseDashboardEventsSkeleton } from '@/app/student/_components/Skeletons';
 import { cn } from "@/lib/utils";
+import Leaderboard from '@/components/Leaderboard';
+import { useLeaderboard } from '@/hooks/useLeaderboard';
 
 import {
   Select,
@@ -55,6 +57,7 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
   const { completedClassesData, loading: classesLoading, error: classesError } = useCompletedClasses(courseId);
   const { latestCourseData, loading: latestCourseLoading, error: latestCourseError } = useLatestUpdatedCourse(courseId);
   const { mentors: mentorshipMentors } = useMentors('', Boolean(latestCourseData?.mentorshipEnabled), 1000, 0);
+  const { topEntries: leaderboardEntries, selfEntry: leaderboardSelfEntry, isSelfInTopFive, loading: leaderboardLoading, error: leaderboardError } = useLeaderboard(courseId);
   const { width } = useWindowSize();
   const isMobile = width < 768;
 
@@ -900,90 +903,82 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
 
   return (
     <div className="min-h-screen bg-background">
-      <div className="w-full">
-        {/* Course Information Banner - Full Width */}
-        <div className="w-full rounded-b-lg shadow-8dp bg-gradient-to-br from-primary/8 via-background to-accent/8  border-border/50">
-          <div className="max-w-[89rem] mx-auto p-6 md:p-8">
-            {/* Desktop Layout */}
-            <div className="hidden border md:flex flex-col md:flex-row items-start gap-6 mb-0 rounded-lg bg-white p-6 border shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300">
-
-              <div className="flex-shrink-0">
-                <Image
-                  src={validCourseCoverImage}
-                  alt={courseName}
-                  width={128}
-                  height={128}
-                  className="rounded-lg object-contain"
-                />
-              </div>
-              <div className="flex-1">
-                <div className="flex justify-between items-start mb-4">
-                  <div className="flex-1">
-                    <h1 className="text-2xl md:text-3xl font-heading font-bold mb-2 text-left">{courseName}</h1>
-                    <TruncatedDescription text={courseDescription} maxLength={250} className="text-base md:text-lg text-muted-foreground mb-4 text-left" />
-                    <div className="flex items-center gap-2 mb-4">
-                      {/* <Avatar className="w-8 h-8">
-                          <AvatarImage src={validInstructorAvatar || '/logo.PNG'} />
-                          <AvatarFallback>{instructorName ? instructorName[0] : 'U'}</AvatarFallback>
-                        </Avatar> */}
-                      <span className="font-medium capitalize text-sm ">Instructor:- {instructorName}</span>
-                    </div>
-                  </div>
-                  {validCollaborator ? <div className="flex items-center gap-2">
-                    <p className="text-sm font-bold text-muted-foreground">In Collaboration With</p>
-                    <Image
-                      src={validCollaborator}
-                      alt="Collaborator Brand"
-                      width={75}
-                      height={56}
-                      className="h-12"
-                    />
-                  </div> : collaborator ?
-                    <div className="flex  items-center gap-2">
-                      <p className="text-sm font-bold text-muted-foreground ">In Collaboration With</p>
-                      <p className="text-sm font-bold text-primary">{collaborator}</p>
-                    </div> : ''}
-                </div>
-              </div>
-            </div>
-
-            {/* Mobile Layout */}
-            <div className="md:hidden mb-3">
-              <Image
-                src={validCourseCoverImage}
-                alt={courseName}
-                width={400}
-                height={160}
-                className="w-full h-40 rounded-lg object-cover mb-4"
-              />
-              <h1 className="text-2xl font-heading font-bold mb-2 text-left">{courseName}</h1>
-              <TruncatedDescription text={courseDescription} maxLength={150} className="text-base text-muted-foreground mb-4 text-left" />
-              <div className="flex items-center gap-2 mb-4">
-                {/* <Avatar className="w-8 h-8">
-                  <AvatarImage src={validInstructorAvatar || '/logo.PNG'} />
-                  <AvatarFallback>{instructorName ? instructorName[0] : 'U'}</AvatarFallback>
-                </Avatar> */}
-                <span className="font-medium capitalize text-sm ">Instructor:- {instructorName}</span>
-              </div>
-              {validCollaborator && <div className="flex items-center gap-2 mb-4">
-                <p className="text-sm font-bold text-muted-foreground">In Collaboration With</p>
-                <Image
-                  src={validCollaborator}
-                  alt="Collaborator Brand"
-                  width={48}
-                  height={48}
-                  className="h-12"
-                />
-              </div>}
-            </div>
-
-          </div>
-        </div>
-
-        <div className="max-w-[88rem] mx-auto px-4 md:px-6 pt-4 pb-8">
+      <div className="max-w-[88rem] mx-auto px-4 md:px-6 pt-4 pb-8">
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,4fr)_minmax(260px,1fr)] lg:items-start">
             {/* Left Column - Stats and Course Modules */}
             <div className="space-y-6 min-w-0">
+              <div className="w-full rounded-lg border bg-white p-4 md:p-5 shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300">
+                <div className="hidden md:flex flex-col md:flex-row items-start gap-6 mb-0">
+                  <div className="flex-shrink-0">
+                    <Image
+                      src={validCourseCoverImage}
+                      alt={courseName}
+                      width={128}
+                      height={128}
+                      className="rounded-lg object-contain"
+                    />
+                  </div>
+                  <div className="flex-1">
+                    <div className="flex justify-between items-start mb-4">
+                      <div className="flex-1">
+                        <h1 className="text-2xl md:text-3xl font-heading font-bold mb-2 text-left">{courseName}</h1>
+                        <TruncatedDescription text={courseDescription} maxLength={250} className="text-base md:text-lg text-muted-foreground mb-4 text-left" />
+                        <div className="flex items-center gap-2 mb-4">
+                          {/* <Avatar className="w-8 h-8">
+                          <AvatarImage src={validInstructorAvatar || '/logo.PNG'} />
+                          <AvatarFallback>{instructorName ? instructorName[0] : 'U'}</AvatarFallback>
+                        </Avatar> */}
+                          <span className="font-medium capitalize text-sm ">Instructor:- {instructorName}</span>
+                        </div>
+                      </div>
+                      {validCollaborator ? <div className="flex items-center gap-2">
+                          <p className="text-sm font-bold text-muted-foreground">In Collaboration With</p>
+                          <Image
+                            src={validCollaborator}
+                            alt="Collaborator Brand"
+                            width={75}
+                            height={56}
+                            className="h-12"
+                          />
+                        </div> : collaborator ?
+                        <div className="flex  items-center gap-2">
+                          <p className="text-sm font-bold text-muted-foreground ">In Collaboration With</p>
+                          <p className="text-sm font-bold text-primary">{collaborator}</p>
+                        </div> : ''}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="md:hidden mb-0">
+                  <Image
+                    src={validCourseCoverImage}
+                    alt={courseName}
+                    width={400}
+                    height={160}
+                    className="w-full h-40 rounded-lg object-cover mb-4"
+                  />
+                  <h1 className="text-2xl font-heading font-bold mb-2 text-left">{courseName}</h1>
+                  <TruncatedDescription text={courseDescription} maxLength={150} className="text-base text-muted-foreground mb-4 text-left" />
+                  <div className="flex items-center gap-2 mb-4">
+                    {/* <Avatar className="w-8 h-8">
+                      <AvatarImage src={validInstructorAvatar || '/logo.PNG'} />
+                      <AvatarFallback>{instructorName ? instructorName[0] : 'U'}</AvatarFallback>
+                    </Avatar> */}
+                    <span className="font-medium capitalize text-sm ">Instructor:- {instructorName}</span>
+                  </div>
+                  {validCollaborator && <div className="flex items-center gap-2 mb-4">
+                      <p className="text-sm font-bold text-muted-foreground">In Collaboration With</p>
+                      <Image
+                        src={validCollaborator}
+                        alt="Collaborator Brand"
+                        width={48}
+                        height={48}
+                        className="h-12"
+                      />
+                    </div>}
+                </div>
+              </div>
+
               <div className="w-full rounded-lg bg-white p-4 md:p-5 border shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300">
                 <div className="space-y-4">
                   <div className="flex items-center gap-3 w-full">
@@ -1412,6 +1407,25 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
                 </CardContent>
               </Card>
 
+              {latestCourseData?.leaderboardEnabled && (
+                <Card className="w-full shadow-4dp text-left rounded-lg bg-white border shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300">
+                  <CardHeader className="pb-3">
+                    <CardTitle className="text-xl">Leaderboard</CardTitle>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <div className="space-y-4">
+                      <Leaderboard
+                        entries={leaderboardEntries}
+                        loading={leaderboardLoading}
+                        error={leaderboardError}
+                        selfEntry={leaderboardSelfEntry}
+                        showSelfEntry={!isSelfInTopFive}
+                      />
+                    </div>
+                  </CardContent>
+                </Card>
+              )}
+
               {/* Attendance */}
               <Card className="w-full text-left rounded-lg border shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300">
                 <CardHeader className="pb-3">
@@ -1645,7 +1659,6 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
             </div>
           </div>
         </div>
-      </div>
     </div>
   );
 };

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import {LeaderboardProps} from '@/components/appComponentFileType'
+
+
+const initials = (name: string) => {
+  if (!name) return ''
+  return name.split(' ').map(n => n[0]).slice(0,2).join('').toUpperCase()
+}
+
+const SkeletonLoader = () => (
+  <div className="space-y-2">
+    {[...Array(10)].map((_, i) => (
+      <div key={i} className="flex items-center justify-between py-3 px-1">
+        <div className="flex items-center gap-3 flex-1">
+          <div className="w-6 h-4 bg-muted rounded animate-pulse" />
+          <div className="w-9 h-9 rounded-full bg-muted animate-pulse" />
+          <div className="w-24 h-4 bg-muted rounded animate-pulse" />
+        </div>
+        <div className="w-12 h-4 bg-muted rounded animate-pulse" />
+      </div>
+    ))}
+  </div>
+)
+
+export default function Leaderboard({ entries, loading = false, error = null, selfEntry = null, showSelfEntry = false, }: LeaderboardProps) {
+  if (loading) {
+    return <SkeletonLoader />
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <p className="text-sm text-muted-foreground">Failed to load leaderboard</p>
+      </div>
+    )
+  }
+
+  if (entries.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <p className="text-sm text-muted-foreground">No activity recorded yet.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        {entries.map((e, idx) => (
+          <div
+            key={`${e.rank}-${e.name}-${idx}`}
+            className={`flex items-center justify-between py-3 px-1 rounded-lg transition-all duration-150 ${e.isYou ? 'bg-emerald-50 border border-emerald-100' : ''}`}
+          >
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <div className="text-sm font-semibold text-muted-foreground w-6 text-left">#{e.rank}</div>
+              <div className="w-9 h-9 rounded-full bg-emerald-700 flex items-center justify-center text-white font-semibold">{initials(e.name)}</div>
+              <div className="min-w-0 flex-1 text-sm font-medium truncate" title={`${e.name}${e.isYou ? ' (You)' : ''}`}>
+                {e.name}{e.isYou ? ' (You)' : ''}
+              </div>
+            </div>
+
+            <div className="flex items-center gap-1">
+              <div className="text-orange-500 font-semibold">{e.points}</div>
+              <div className="text-xs text-muted-foreground">pt</div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {showSelfEntry && selfEntry && (
+      <div className="border-t border-border pt-2">
+        <p className="mb-3 text-xs text-muted-foreground">
+          Every Day Counts!
+        </p>
+
+        <div className="flex items-center justify-between py-2 px-1">
+          <div className="flex items-center gap-2 min-w-0 flex-1">
+            <div className="text-sm font-semibold text-muted-foreground w-6 text-left">
+              #{selfEntry.rank}
+            </div>
+
+            <div className="w-9 h-9 rounded-full bg-emerald-700 flex items-center justify-center text-white font-semibold shrink-0">
+              {initials(selfEntry.name)}
+            </div>
+
+            <div
+              className="min-w-0 flex-1 text-sm font-medium truncate"
+              title={`${selfEntry.name} (You)`}
+            >
+              {selfEntry.name} (You)
+            </div>
+          </div>
+
+          <div className="flex items-center gap-1">
+            <div className="text-orange-500 font-semibold">
+              {selfEntry.points}
+            </div>
+            <div className="text-xs text-muted-foreground">pt</div>
+          </div>
+        </div>
+      </div>
+    )}
+    </div>
+  )
+}

--- a/src/components/appComponentFileType.ts
+++ b/src/components/appComponentFileType.ts
@@ -21,3 +21,20 @@ export interface QuizQuestionDetails {
     difficulty: string
     tagId: number
 }
+
+// ui/leaderboard.tsx
+
+export type Entry = {
+  rank: number
+  name: string
+  points: number
+  isYou?: boolean
+}
+
+export interface LeaderboardProps {
+  entries: Entry[]
+  loading?: boolean
+  error?: string | null
+  selfEntry?: Entry | null
+  showSelfEntry?: boolean
+}

--- a/src/hooks/hookType.ts
+++ b/src/hooks/hookType.ts
@@ -486,6 +486,7 @@ export interface LatestUpdatedCourseData {
   bootcampName: string;
   newChapter: NewChapter;
   mentorshipEnabled?: boolean;
+  leaderboardEnabled: boolean;
 }
 
 export interface LatestUpdatedCourseResponse {
@@ -493,6 +494,7 @@ export interface LatestUpdatedCourseResponse {
   code: number;
   isSuccess: boolean;
   mentorshipEnabled: boolean;
+  leaderboardEnabled: boolean;
   data: LatestUpdatedCourseData;
 }
 
@@ -697,6 +699,7 @@ export interface BootcampSettingsData {
   type: string;
   isModuleLocked: boolean;
   mentorshipEnabled: boolean;
+  leaderboardEnabled: boolean;
 }
 
 export interface UseBootcampSettingsReturn {

--- a/src/hooks/useBootcampSettings.tsx
+++ b/src/hooks/useBootcampSettings.tsx
@@ -32,7 +32,8 @@ const useBootcampSettings = (courseId: string): UseBootcampSettingsReturn => {
       setBootcampSettings({
         type: settings.type,
         isModuleLocked: settings.isModuleLocked ?? false,
-        mentorshipEnabled: settings.mentorshipEnabled ?? false
+        mentorshipEnabled: settings.mentorshipEnabled ?? false,
+        leaderboardEnabled: settings.leaderboardEnabled ?? false
       });
       setError(null);
     } catch (err: any) {

--- a/src/hooks/useLatestUpdatedCourse.tsx
+++ b/src/hooks/useLatestUpdatedCourse.tsx
@@ -26,6 +26,7 @@ export const useLatestUpdatedCourse = (courseId: string) => {
           setLatestCourseData({
             ...response.data.data,
             mentorshipEnabled: response.data.mentorshipEnabled,
+            leaderboardEnabled: response.data.leaderboardEnabled,
           });
         } else {
           setError(response.data.message || 'Failed to fetch latest updated course');

--- a/src/hooks/useLeaderboard.ts
+++ b/src/hooks/useLeaderboard.ts
@@ -1,0 +1,77 @@
+import { useState, useEffect } from 'react';
+import { api } from '@/utils/axios.config';
+
+type LeaderboardEntry = {
+  rank: number;
+  name: string;
+  points: number;
+  isYou?: boolean;
+};
+
+type UseLeaderboardReturn = {
+  topEntries: LeaderboardEntry[];
+  selfEntry: LeaderboardEntry | null;
+  isSelfInTopFive: boolean;
+  loading: boolean;
+  error: string | null;
+};
+
+export function useLeaderboard(courseId: string): UseLeaderboardReturn {
+  const [topEntries, setTopEntries] = useState<LeaderboardEntry[]>([]);
+  const [selfEntry, setSelfEntry] = useState<LeaderboardEntry | null>(null);
+  const [isSelfInTopFive, setIsSelfInTopFive] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!courseId) return;
+
+    const fetchLeaderboard = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await api.get(
+          `/leaderboard/student/data?limit=5`
+        );
+
+        const data = res.data;
+
+        if (!data.success) throw new Error('Leaderboard fetch unsuccessful');
+
+        const currentLearnerId = data.currentLearner?.learnerId;
+
+        const mapped: LeaderboardEntry[] = (data.leaderboard ?? []).map(
+          (item: { rank: number; name: string; totalPoints: number; learnerId: number }) => ({
+            rank: item.rank,
+            name: item.name,
+            points: item.totalPoints,
+            isYou: item.learnerId === currentLearnerId,
+          })
+        );
+
+        const self: LeaderboardEntry | null = data.currentLearner
+          ? {
+              rank: data.currentLearner.rank,
+              name: data.currentLearner.name,
+              points: data.currentLearner.totalPoints,
+              isYou: true,
+            }
+          : null;
+
+        const selfInTop = mapped.some((e) => e.isYou);
+
+        setTopEntries(mapped);
+        setSelfEntry(self);
+        setIsSelfInTopFive(selfInTop);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unknown error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchLeaderboard();
+  }, [courseId]);
+
+  return { topEntries, selfEntry, isSelfInTopFive, loading, error };
+}


### PR DESCRIPTION
Added a leaderboard toggle in admin settings to enable/disable the leaderboard.
Display leaderboard on the course dashboard only when it is enabled from the admin side.
Added leaderboard UI to show the top 5 ranked learners.
Created hook to fetch leaderboard data from the API.