### PR TITLE
Add orgId support to student mentors and sessions routes

### DIFF
--- a/src/app/student/_components/Header.tsx
+++ b/src/app/student/_components/Header.tsx
@@ -10,6 +10,7 @@ import StudentProfileDropDown from './StudentProfileDropDown'
 import useLearnerProfileStrength from '@/hooks/useLearnerProfileStrength'
 import { useOnboardingStorage } from '@/hooks/use-profile'
 import { useLatestUpdatedCourse } from '@/hooks/useLatestUpdatedCourse'
+import { getMentorsHref } from '@/utils/studentMentorshipRoutes'
 
 const Header = () => {
     const { isDark, toggleTheme } = useThemeStore()
@@ -26,6 +27,8 @@ const Header = () => {
     const courseIdMatch = pathname.match(/\/course\/([^\/]+)/)
     const courseIdFromPath = courseIdMatch?.[1]
     const courseIdFromQuery = searchParams.get('courseId')
+    const orgIdFromQuery = searchParams.get('orgId')
+    const currentOrgId = (orgId as string | undefined) || orgIdFromQuery || ''
     const currentCourseId = courseIdFromPath || courseIdFromQuery || ''
     const { latestCourseData } = useLatestUpdatedCourse(currentCourseId)
     const shouldShowMentorshipLinks = Boolean(latestCourseData?.mentorshipEnabled)
@@ -56,7 +59,7 @@ const Header = () => {
     const handleSyllabusClick = () => {
         const courseId = getCurrentCourseId()
         if (courseId) {
-            router.push(`/student/course/${courseId}/org/${orgId}/courseSyllabus`)
+            router.push(`/student/course/${courseId}/org/${currentOrgId}/courseSyllabus`)
             return
         }
 
@@ -66,7 +69,7 @@ const Header = () => {
     const handleMentorshipClick = () => {
         const courseId = getCurrentCourseId()
         if (courseId) {
-            router.push(`/student/mentors?courseId=${courseId}`)
+            router.push(getMentorsHref({ courseId, orgId: currentOrgId }))
             return
         }
 

--- a/src/app/student/_components/MentorBookingDrawer.tsx
+++ b/src/app/student/_components/MentorBookingDrawer.tsx
@@ -12,12 +12,14 @@ import { useStudentMentorMetrics } from "@/hooks/useStudentMentorMetrics"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Sheet, SheetContent, SheetHeader, SheetTitle  } from "@/components/ui/sheet"
+import { getSessionsHref } from "@/utils/studentMentorshipRoutes"
 
 type MentorBookingDrawerProps = {
   mentor: Mentor | null
   open: boolean
   onOpenChange: (open: boolean) => void
   courseId?: string
+  orgId?: string
 }
 
 const formatSlotDate = (value: string) =>
@@ -49,6 +51,7 @@ export default function MentorBookingDrawer({
   open,
   onOpenChange,
   courseId,
+  orgId,
 }: MentorBookingDrawerProps) {
   const [selectedSlotId, setSelectedSlotId] = useState<number | null>(null)
   const [bookedSlotDetails, setBookedSlotDetails] = useState<MentorAvailabilitySlot | null>(null)
@@ -353,11 +356,7 @@ export default function MentorBookingDrawer({
 
                     {/* BUTTON */}
                     <Link
-                      href={
-                        courseId
-                          ? `/student/sessions?courseId=${courseId}`
-                          : "/student/sessions"
-                      }
+                      href={getSessionsHref({ courseId, orgId })}
                       className="mt-4 w-full"
                     >
                       <Button

--- a/src/app/student/_components/MentorshipTabs.tsx
+++ b/src/app/student/_components/MentorshipTabs.tsx
@@ -2,24 +2,23 @@
 
 import Link from "next/link"
 import { usePathname, useSearchParams } from "next/navigation"
+import { getMentorsHref, getSessionsHref } from "@/utils/studentMentorshipRoutes"
 
 type Props = {
   courseId?: string
+  orgId?: string
 }
 
-export default function MentorshipTabs({ courseId }: Props) {
+export default function MentorshipTabs({ courseId, orgId }: Props) {
   const searchParams = useSearchParams()
   const pathname = usePathname()
 
   const cid = courseId ?? searchParams?.get("courseId") ?? ""
+  const oid = orgId ?? searchParams?.get("orgId") ?? ""
 
-  const mentorsHref = cid
-    ? `/student/mentors?courseId=${cid}`
-    : "/student/mentors"
-
-  const sessionsHref = cid
-    ? `/student/sessions?courseId=${cid}`
-    : "/student/sessions"
+  const routeContext = { courseId: cid, orgId: oid }
+  const mentorsHref = getMentorsHref(routeContext)
+  const sessionsHref = getSessionsHref(routeContext)
 
   const isMentorsTabActive = pathname?.startsWith("/student/mentors")
   const isSessionsTabActive = pathname?.startsWith("/student/sessions")

--- a/src/app/student/_pages/CourseDashboardPage.tsx
+++ b/src/app/student/_pages/CourseDashboardPage.tsx
@@ -31,6 +31,7 @@ import { ModuleContentCounts, TopicItem } from '@/app/student/_pages/pageStudent
 import { formatUpcomingItem } from "@/utils/students"
 import { CourseDashboardSkeleton, CourseDashboardEventsSkeleton } from '@/app/student/_components/Skeletons';
 import { cn } from "@/lib/utils";
+import { getMentorsHref, getSessionJoinHref, getSessionsHref } from "@/utils/studentMentorshipRoutes";
 // import Leaderboard from '@/components/Leaderboard';
 // import { useLeaderboard } from '@/hooks/useLeaderboard';
 
@@ -56,7 +57,7 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
   const { upcomingEventsData, loading: eventsLoading, error: eventsError } = useUpcomingEvents(courseId);
   const { completedClassesData, loading: classesLoading, error: classesError } = useCompletedClasses(courseId);
   const { latestCourseData, loading: latestCourseLoading, error: latestCourseError } = useLatestUpdatedCourse(courseId);
-  const { mentors: mentorshipMentors } = useMentors('', Boolean(latestCourseData?.mentorshipEnabled), 1000, 0);
+  const { mentors: mentorshipMentors } = useMentors('', Boolean(latestCourseData?.mentorshipEnabled), 1000, 0, orgId as string | undefined);
   // const { topEntries: leaderboardEntries, selfEntry: leaderboardSelfEntry, isSelfInTopFive, loading: leaderboardLoading, error: leaderboardError } = useLeaderboard(courseId);
   const { width } = useWindowSize();
   const isMobile = width < 768;
@@ -71,7 +72,7 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
     {
       label: "Find a Mentor",
       sub: availableMentorCount > 0 ? `${availableMentorCount} mentor available now` : "No mentors available now",
-      href: `/student/mentors?courseId=${courseId}`,
+      href: getMentorsHref({ courseId, orgId: orgId as string | undefined }),
       icon: Search,
       color: "text-primary",
       bg: "bg-primary/10",
@@ -79,7 +80,7 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
     {
       label: "My Sessions",
       sub: `${mentorshipSessionCount} upcoming`,
-      href: `/student/sessions?courseId=${courseId}`,
+      href: getSessionsHref({ courseId, orgId: orgId as string | undefined }),
       icon: CalendarDays,
       color: "text-accent",
       bg: "bg-accent/10",
@@ -278,7 +279,7 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
   const getMentorSessionJoinHref = (item: MentorSessionEvent) => {
     if (!item.meetingLink) return null;
 
-    return `/student/sessions/${item.id}/join?joinUrl=${encodeURIComponent(item.meetingLink)}`;
+    return getSessionJoinHref(item.id, item.meetingLink, { courseId, orgId: orgId as string | undefined });
   };
 
   const getEventActionText = (type: string) => {
@@ -1293,7 +1294,7 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
                                   <h4 className="font-medium text-base hover:text-primary hover:underline underline-offset-[4px]">
                                     {eventType === 'Mentor Session' ? (
                                       <Link
-                                        href={`/student/sessions?courseId=${courseId}`}
+                                        href={getSessionsHref({ courseId, orgId: orgId as string | undefined })}
                                         target="_self"
                                         className="hover:text-primary hover:underline underline-offset-[4px]"
                                       >

--- a/src/app/student/mentors/[id]/book/page.tsx
+++ b/src/app/student/mentors/[id]/book/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/hooks/useMentorAvailability";
 import { useBookMentorSlot } from "@/hooks/useBookMentorSlot";
 import { useStudentMentorMetrics } from "@/hooks/useStudentMentorMetrics";
+import { getMentorProfileHref, getMentorsHref } from "@/utils/studentMentorshipRoutes";
 
 const getMentorId = (idParam: string | string[] | undefined) => {
   if (Array.isArray(idParam)) {
@@ -65,7 +66,9 @@ export default function BookSessionPage() {
   const searchParams = useSearchParams();
   const mentorId = getMentorId(params["id"] as string | string[] | undefined);
   const courseId = searchParams.get("courseId") || "";
-  const organizationId = searchParams.get("organizationId") || undefined;
+  const orgId = searchParams.get("orgId") || "";
+  const organizationId = searchParams.get("organizationId") || orgId || undefined;
+  const routeContext = { courseId, orgId };
   const [selectedSlotId, setSelectedSlotId] = useState<number | null>(null);
 
   const {
@@ -120,7 +123,7 @@ export default function BookSessionPage() {
 
       {/* Back */}
       <Link
-        href={mentorId ? `/student/mentors/${mentorId}${courseId ? `?courseId=${courseId}` : ""}` : (courseId ? `/student/mentors?courseId=${courseId}` : "/student/mentors")}
+        href={mentorId ? getMentorProfileHref(mentorId, routeContext) : getMentorsHref(routeContext)}
         className="flex items-center text-sm text-gray-500 hover:text-gray-700"
       >
         <ArrowLeft size={16} className="mr-1" />

--- a/src/app/student/mentors/[id]/page.tsx
+++ b/src/app/student/mentors/[id]/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/use-toast";
 import { api } from "@/utils/axios.config";
 import { useMentorProfile } from "@/hooks/useMentorProfile";
+import { getMentorBookHref, getMentorsHref } from "@/utils/studentMentorshipRoutes";
 
 const getMentorId = (idParam: string | string[] | undefined) => {
   if (Array.isArray(idParam)) {
@@ -30,7 +31,9 @@ export default function MentorProfilePage() {
   const searchParams = useSearchParams();
   const mentorId = getMentorId(params["id"] as string | string[] | undefined);
   const courseId = searchParams.get("courseId") || "";
-  const organizationId = searchParams.get("organizationId") || undefined;
+  const orgId = searchParams.get("orgId") || "";
+  const organizationId = searchParams.get("organizationId") || orgId || undefined;
+  const routeContext = { courseId, orgId };
   const [isGoogleConnecting, setIsGoogleConnecting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null)
 
@@ -106,7 +109,7 @@ export default function MentorProfilePage() {
     return (
       <div className="max-w-7xl mx-auto p-6 space-y-4">
         <Link
-          href={courseId ? `/student/mentors?courseId=${courseId}` : "/student/mentors"}
+          href={getMentorsHref(routeContext)}
           className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700"
         >
           <ArrowLeft size={16} />
@@ -123,7 +126,7 @@ export default function MentorProfilePage() {
 
       {/* Back button */}
       <Link
-        href={courseId ? `/student/mentors?courseId=${courseId}` : "/student/mentors"}
+        href={getMentorsHref(routeContext)}
         className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700"
       >
         <ArrowLeft size={16} />
@@ -249,7 +252,7 @@ export default function MentorProfilePage() {
           </div>
 
           <Link
-            href={mentorId ? `/student/mentors/${mentorId}/book${courseId ? `?courseId=${courseId}` : ""}` : (courseId ? `/student/mentors?courseId=${courseId}` : "/student/mentors")}
+            href={mentorId ? getMentorBookHref(mentorId, routeContext) : getMentorsHref(routeContext)}
             className={`w-full py-3 rounded-lg flex items-center justify-center gap-2 font-medium transition-all ${
               acceptsNewMentees
                 ? "bg-green-800 text-white hover:bg-green-900"

--- a/src/app/student/mentors/page.tsx
+++ b/src/app/student/mentors/page.tsx
@@ -48,6 +48,7 @@ export default function MentorsPage() {
     const offset = (page - 1) * limit
     const searchQuery = searchParams.get("search")?.trim() || ""
     const courseId = searchParams.get("courseId") || ""
+    const orgId = searchParams.get("orgId") || ""
     const [showAllMentors, setShowAllMentors] = useState(false)
     const [selectedMentor, setSelectedMentor] = useState<Mentor | null>(null)
     const [isDrawerOpen, setIsDrawerOpen] = useState(false)
@@ -56,14 +57,15 @@ export default function MentorsPage() {
         searchQuery,
         showAllMentors,
         limit,
-        offset
+        offset,
+        orgId || undefined
     )
 
     const {
         mentors: availableMentorPool,
         loading: availableMentorPoolLoading,
         error: availableMentorPoolError,
-    } = useMentors(searchQuery, !showAllMentors, 1000, 0)
+    } = useMentors(searchQuery, !showAllMentors, 1000, 0, orgId || undefined)
 
     const { metrics, loading: metricsLoading } = useStudentMentorMetrics()
 
@@ -99,12 +101,13 @@ export default function MentorsPage() {
             searchTerm: searchQuery,
             limit,
             offset: nextOffset,
+            organizationId: orgId || undefined,
         })
-    }, [showAllMentors, refetchMentors, searchQuery, limit])
+    }, [showAllMentors, refetchMentors, searchQuery, limit, orgId])
     const fetchSuggestionsApi = useCallback(async (query: string) => {
         try {
             const response = await api.get<MentorsSearchResponse>(
-                `/student/mentors?search=${encodeURIComponent(query)}`
+                `/student/mentors?search=${encodeURIComponent(query)}${orgId ? `&organizationId=${encodeURIComponent(orgId)}` : ""}`
             );
 
             const mentorList = parseMentors(response.data);
@@ -117,7 +120,7 @@ export default function MentorsPage() {
             console.error("Error fetching mentor suggestions:", fetchError);
             return [];
         }
-    }, []);
+    }, [orgId]);
 
     const fetchSearchResultsApi = useCallback(async () => {
         return [];
@@ -140,7 +143,7 @@ export default function MentorsPage() {
                 {/* <p className="mt-1 text-sm text-gray-500 text-left">Browse mentors or review your booked sessions.</p> */}
             </div>
 
-            <MentorshipTabs courseId={courseId} />
+            <MentorshipTabs courseId={courseId} orgId={orgId} />
 
             {/* Booking Metrics Banner */}
             {!metricsLoading && metrics && (
@@ -389,6 +392,7 @@ export default function MentorsPage() {
                 open={isDrawerOpen}
                 onOpenChange={setIsDrawerOpen}
                 courseId={courseId}
+                orgId={orgId}
             />
         </div>
     );

--- a/src/app/student/sessions/[id]/cancel/page.tsx
+++ b/src/app/student/sessions/[id]/cancel/page.tsx
@@ -2,9 +2,10 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 import { useCancelMentorSlotBooking } from "@/hooks/useCancelMentorSlotBooking";
+import { getSessionsHref } from "@/utils/studentMentorshipRoutes";
 
 const getBookingIdFromParam = (
 	idParam: string | string[] | undefined
@@ -21,9 +22,12 @@ const getBookingIdFromParam = (
 
 export default function CancelBookingPage() {
 	const params = useParams();
+	const searchParams = useSearchParams();
 	const bookingId = getBookingIdFromParam(
 		params["id"] as string | string[] | undefined
 	);
+	const courseId = searchParams.get("courseId") || "";
+	const orgId = searchParams.get("orgId") || "";
 
 	const [reason, setReason] = useState("");
 	const [validationError, setValidationError] = useState<string | null>(null);
@@ -49,7 +53,7 @@ export default function CancelBookingPage() {
 	return (
 		<div className="max-w-3xl mx-auto p-6 space-y-6">
 			<Link
-				href="/student/sessions"
+				href={getSessionsHref({ courseId, orgId })}
 				className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700"
 			>
 				<ArrowLeft size={16} />

--- a/src/app/student/sessions/[id]/join/page.tsx
+++ b/src/app/student/sessions/[id]/join/page.tsx
@@ -2,11 +2,15 @@
 
 import { useEffect } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
+import { getSessionsHref } from "@/utils/studentMentorshipRoutes"
 
 export default function JoinSessionPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const joinUrl = searchParams.get("joinUrl")?.trim() || ""
+  const courseId = searchParams.get("courseId") || ""
+  const orgId = searchParams.get("orgId") || ""
+  const sessionsHref = getSessionsHref({ courseId, orgId })
 
   const isAllowedMeetingHost = (hostname: string) => {
     const normalizedHost = hostname.toLowerCase()
@@ -16,7 +20,7 @@ export default function JoinSessionPage() {
 
   useEffect(() => {
     if (!joinUrl) {
-      router.replace("/student/sessions")
+      router.replace(sessionsHref)
       return
     }
 
@@ -26,15 +30,15 @@ export default function JoinSessionPage() {
       const isAllowedHost = isAllowedMeetingHost(parsedMeetingUrl.hostname)
 
       if (!isHttps || !isAllowedHost) {
-        router.replace("/student/sessions")
+        router.replace(sessionsHref)
         return
       }
 
       window.location.replace(parsedMeetingUrl.toString())
     } catch {
-      router.replace("/student/sessions")
+      router.replace(sessionsHref)
     }
-  }, [joinUrl, router])
+  }, [joinUrl, router, sessionsHref])
 
   return null
 }

--- a/src/app/student/sessions/[id]/reschedule/page.tsx
+++ b/src/app/student/sessions/[id]/reschedule/page.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, Calendar, Clock } from "lucide-react";
 import { useRescheduleMentorSlotBooking } from "@/hooks/useRescheduleMentorSlotBooking";
 import { useGetRescheduleSlots } from "@/hooks/useGetRescheduleSlots";
 import { useMentorProfile } from "@/hooks/useMentorProfile";
+import { getSessionsHref } from "@/utils/studentMentorshipRoutes";
 
 const getBookingIdFromParam = (
 	idParam: string | string[] | undefined
@@ -28,7 +29,9 @@ export default function RescheduleBookingPage() {
 		params["id"] as string | string[] | undefined
 	);
 	const mentorId = searchParams.get("mentorId") || undefined;
-	const organizationId = searchParams.get("organizationId") || undefined;
+	const courseId = searchParams.get("courseId") || "";
+	const orgId = searchParams.get("orgId") || "";
+	const organizationId = searchParams.get("organizationId") || orgId || undefined;
 	const currentSlotIdParam = searchParams.get("currentSlotId");
 	const currentSlotId = currentSlotIdParam ? Number(currentSlotIdParam) : null;
 
@@ -119,7 +122,7 @@ export default function RescheduleBookingPage() {
 	return (
 		<div className="max-w-3xl mx-auto p-6 space-y-6">
 			<Link
-				href="/student/sessions"
+				href={getSessionsHref({ courseId, orgId })}
 				className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700"
 			>
 				<ArrowLeft size={16} />

--- a/src/app/student/sessions/page.tsx
+++ b/src/app/student/sessions/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react"
 import Link from "next/link"
-import { usePathname, useSearchParams } from "next/navigation"
+import { useSearchParams } from "next/navigation"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
@@ -37,6 +37,13 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import { toast } from "@/components/ui/use-toast"
 import { useSubmitStudentFeedback } from "@/hooks/useSubmitStudentFeedback"
+import {
+  getMentorProfileHref,
+  getMentorsHref,
+  getSessionCancelHref,
+  getSessionJoinHref,
+  getSessionRescheduleHref,
+} from "@/utils/studentMentorshipRoutes"
 
 type Tab = "upcoming" | "completed" | "cancelled"
 
@@ -141,12 +148,9 @@ function RecordingLink({ bookingId }: { bookingId: number }) {
 
 export default function MySessions() {
   const searchParams = useSearchParams()
-  const pathname = usePathname()
   const courseId = searchParams.get("courseId") || ""
-  const mentorsHref = courseId ? `/student/mentors?courseId=${courseId}` : "/student/mentors"
-  const sessionsHref = courseId ? `/student/sessions?courseId=${courseId}` : "/student/sessions"
-  const isMentorsTabActive = pathname.startsWith("/student/mentors")
-  const isSessionsTabActive = pathname.startsWith("/student/sessions")
+  const orgId = searchParams.get("orgId") || ""
+  const routeContext = { courseId, orgId }
   const [activeTab, setActiveTab] = useState<Tab>("upcoming")
   const [nowTimestamp, setNowTimestamp] = useState(() => Date.now())
   const [feedbackBookingId, setFeedbackBookingId] = useState<number | null>(null)
@@ -230,7 +234,7 @@ export default function MySessions() {
         {/* <p className="mt-1 text-sm text-gray-500 text-left">Browse mentors or manage your sessions.</p> */}
       </div>
 
-      <MentorshipTabs courseId={courseId} />
+      <MentorshipTabs courseId={courseId} orgId={orgId} />
       {/* TABS */}
 
       <div className="flex items-center  rounded-full p-1 w-fit gap-3">
@@ -336,7 +340,7 @@ export default function MySessions() {
               <div className="border-t pt-4" />
 
               <Link
-                href={`/student/mentors/${session.mentorUserId}`}
+                href={getMentorProfileHref(session.mentorUserId, routeContext)}
                 className="text-green-600 text-sm font-medium flex items-center gap-2"
               >
 
@@ -376,7 +380,7 @@ export default function MySessions() {
 
             <Button className="mt-4 text-sm text-white px-5 py-2 rounded-lg flex items-center gap-2" asChild>
 
-              <Link href="/student/mentors">
+              <Link href={getMentorsHref(routeContext)}>
                 <Users size={16} />
 
                 Book a Session
@@ -558,7 +562,7 @@ export default function MySessions() {
               >
                 {canJoinNow ? (
                   <Link
-                    href={`/student/sessions/${session.id}/join?joinUrl=${encodeURIComponent(joinUrl)}`}
+                    href={getSessionJoinHref(session.id, joinUrl, routeContext)}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
@@ -580,14 +584,17 @@ export default function MySessions() {
 
               <Button variant="outline" asChild>
                 <Link
-                  href={`/student/sessions/${session.id}/reschedule?currentSlotId=${session.slotAvailabilityId}&mentorId=${session.mentorUserId}`}
+                  href={getSessionRescheduleHref(session.id, routeContext, {
+                    currentSlotId: session.slotAvailabilityId,
+                    mentorId: session.mentorUserId,
+                  })}
                 >
                   Reschedule
                 </Link>
               </Button>
 
               <Button variant="outline" asChild>
-                <Link href={`/student/sessions/${session.id}/cancel`}>
+                <Link href={getSessionCancelHref(session.id, routeContext)}>
                   Cancel
                 </Link>
               </Button>

--- a/src/hooks/useMentors.ts
+++ b/src/hooks/useMentors.ts
@@ -40,6 +40,7 @@ interface GetMentorsParams {
     searchTerm?: string
     limit?: number
     offset?: number
+    organizationId?: string | number
 }
 
 const parseMentorsResponse = (response: MentorsApiResponse): ParsedMentorsResponse => {
@@ -81,7 +82,7 @@ const getErrorMessage = (error: unknown): string => {
     return message || 'Failed to fetch mentors'
 }
 
-export function useMentors(search?: string, initialFetch = true, limit = 10, offset = 0) {
+export function useMentors(search?: string, initialFetch = true, limit = 10, offset = 0, organizationId?: string | number) {
     const [mentors, setMentors] = useState<Mentor[]>([])
     const [loading, setLoading] = useState<boolean>(!!initialFetch)
     const [error, setError] = useState<string | null>(null)
@@ -108,6 +109,10 @@ export function useMentors(search?: string, initialFetch = true, limit = 10, off
                 queryParams.append('offset', String(params.offset))
             }
 
+            if (params.organizationId) {
+                queryParams.append('organizationId', String(params.organizationId))
+            }
+
             const url = `/student/mentors${queryParams.toString() ? `?${queryParams.toString()}` : ''}`
             const response = await api.get<MentorsApiResponse>(url)
             const parsedResponse = parseMentorsResponse(response.data)
@@ -128,9 +133,9 @@ export function useMentors(search?: string, initialFetch = true, limit = 10, off
 
     useEffect(() => {
         if (initialFetch) {
-            getMentors({ searchTerm: search, limit, offset })
+            getMentors({ searchTerm: search, limit, offset, organizationId })
         }
-    }, [initialFetch, getMentors, limit, offset, search])
+    }, [initialFetch, getMentors, limit, offset, organizationId, search])
 
     return {
         mentors,

--- a/src/utils/studentMentorshipRoutes.ts
+++ b/src/utils/studentMentorshipRoutes.ts
@@ -1,0 +1,66 @@
+type MentorshipRouteContext = {
+  courseId?: string | number | null
+  orgId?: string | number | null
+}
+
+type QueryValue = string | number | null | undefined
+
+const appendQuery = (
+  path: string,
+  context: MentorshipRouteContext = {},
+  extraParams: Record<string, QueryValue> = {}
+) => {
+  const params = new URLSearchParams()
+
+  if (context.courseId) {
+    params.set("courseId", String(context.courseId))
+  }
+
+  if (context.orgId) {
+    params.set("orgId", String(context.orgId))
+  }
+
+  Object.entries(extraParams).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== "") {
+      params.set(key, String(value))
+    }
+  })
+
+  const queryString = params.toString()
+  return queryString ? `${path}?${queryString}` : path
+}
+
+export const getMentorsHref = (context: MentorshipRouteContext = {}) =>
+  appendQuery("/student/mentors", context)
+
+export const getSessionsHref = (context: MentorshipRouteContext = {}) =>
+  appendQuery("/student/sessions", context)
+
+export const getMentorProfileHref = (
+  mentorId: string | number,
+  context: MentorshipRouteContext = {}
+) => appendQuery(`/student/mentors/${mentorId}`, context)
+
+export const getMentorBookHref = (
+  mentorId: string | number,
+  context: MentorshipRouteContext = {}
+) => appendQuery(`/student/mentors/${mentorId}/book`, context)
+
+export const getSessionJoinHref = (
+  sessionId: string | number,
+  joinUrl: string,
+  context: MentorshipRouteContext = {}
+) => appendQuery(`/student/sessions/${sessionId}/join`, context, {
+  joinUrl,
+})
+
+export const getSessionRescheduleHref = (
+  sessionId: string | number,
+  context: MentorshipRouteContext = {},
+  extraParams: Record<string, QueryValue> = {}
+) => appendQuery(`/student/sessions/${sessionId}/reschedule`, context, extraParams)
+
+export const getSessionCancelHref = (
+  sessionId: string | number,
+  context: MentorshipRouteContext = {}
+) => appendQuery(`/student/sessions/${sessionId}/cancel`, context)


### PR DESCRIPTION
Added orgId support to student Mentors and Sessions routing, matching the Course module pattern. The update preserves both courseId and orgId across parent pages, detail pages, tabs, dashboard/header navigation, booking flow, session join, reschedule, cancel, redirects, refresh, and direct URL access.