### PR TITLE
 feat: add guided onboarding tour for student dashboard

### DIFF
--- a/src/app/student/_components/Header.tsx
+++ b/src/app/student/_components/Header.tsx
@@ -295,6 +295,7 @@ const Header = () => {
                         </Button>
                         {showMentorshipNavLink && (
                             <Button
+                                id="tour-mentorship"
                                 variant="link"
                                 size="sm"
                                 onClick={handleMentorshipClick}

--- a/src/app/student/_components/MentorshipTabs.tsx
+++ b/src/app/student/_components/MentorshipTabs.tsx
@@ -27,6 +27,7 @@ export default function MentorshipTabs({ courseId, orgId }: Props) {
     <div className="w-full border-b border-[#e8ece8]">
       <div className="flex items-center gap-8">
         <Link
+          id="tour-browse-mentors"
           href={mentorsHref}
           className={`
             relative flex items-center gap-2 px-3 py-2  text-sm transition-all
@@ -58,6 +59,7 @@ export default function MentorshipTabs({ courseId, orgId }: Props) {
         </Link>
 
         <Link
+          id="tour-my-sessions"
           href={sessionsHref}
           className={`
             relative flex items-center gap-2 px-3 py-2  text-sm transition-all

--- a/src/app/student/_components/StudentProfileDropDown.tsx
+++ b/src/app/student/_components/StudentProfileDropDown.tsx
@@ -43,7 +43,8 @@ const StudentProfileDropDown = ({
         <>
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Avatar className="h-9 w-9 cursor-pointer transition-all">
+                    <Avatar 
+                    className="h-9 w-9 cursor-pointer transition-all">
                         <AvatarFallback className="bg-[#2f6f3e] text-white text-base font-semibold">
                             {getUserInitials(studentData?.name)}
                         </AvatarFallback>

--- a/src/app/student/_components/guided-tour/TourContext.tsx
+++ b/src/app/student/_components/guided-tour/TourContext.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { useStudentData } from '@/hooks/useStudentData';
+
+export interface TourStepConfig {
+  id: string;
+  targetSelector: string;
+  title: string;
+  content: string;
+  route?: string;
+  stepNumber: number;
+  totalSteps: number;
+}
+
+interface TourContextType {
+  isOpen: boolean;
+  currentStepIndex: number;
+  steps: TourStepConfig[];
+  activeElementRect: DOMRect | null;
+  isTourCompleted: boolean;
+  startTour: (fromStepIndex?: number) => void;
+  nextStep: () => void;
+  prevStep: () => void;
+  skipTour: () => void;
+  finishTour: () => void;
+  resetTour: () => void;
+}
+
+const TOUR_STEPS: TourStepConfig[] = [
+  {
+    id: 'profile',
+    targetSelector: '#tour-profile',
+    title: 'Profile',
+    content: 'Manage your profile information, update personal details, and access account settings from here.',
+    route: '/student/profile',
+    stepNumber: 1,
+    totalSteps: 5,
+  },
+  {
+    id: 'courses',
+    targetSelector: '#tour-courses',
+    title: 'Courses',
+    content: 'View your enrolled courses and continue your learning journey from this section.',
+    route: '/student',
+    stepNumber: 2,
+    totalSteps: 5,
+  },
+  {
+    id: 'mentorship',
+    targetSelector: '#tour-mentorship',
+    title: 'Mentorship',
+    content: 'Connect with mentors and receive personalized guidance to accelerate your learning and career growth.',
+    route: 'DYNAMIC_COURSE_SYLLABUS',
+    stepNumber: 3,
+    totalSteps: 5,
+  },
+  {
+    id: 'browse-mentors',
+    targetSelector: '#tour-browse-mentors',
+    title: 'Browse Mentors',
+    content: 'Explore available mentors, view their profiles, and book mentorship sessions based on your interests and goals.',
+    route: 'DYNAMIC_MENTORS',
+    stepNumber: 4,
+    totalSteps: 5,
+  },
+  {
+    id: 'book-session',
+    targetSelector: '#tour-mentor-card',
+    title: 'Book a Session',
+    content: 'Click on any available mentor to view their available slots and book a mentorship session.',
+    route: 'DYNAMIC_MENTORS',
+    stepNumber: 4,
+    totalSteps: 5,
+  },
+  {
+    id: 'my-sessions',
+    targetSelector: '#tour-my-sessions',
+    title: 'My Sessions',
+    content: 'Track all your mentorship sessions in one place.',
+    route: 'DYNAMIC_SESSIONS',
+    stepNumber: 5,
+    totalSteps: 5,
+  },
+  {
+    id: 'upcoming-sessions',
+    targetSelector: '#tour-upcoming-sessions',
+    title: 'Upcoming Sessions',
+    content: 'View all your upcoming booked mentorship sessions here.',
+    route: 'DYNAMIC_SESSIONS',
+    stepNumber: 5,
+    totalSteps: 5,
+  },
+  {
+    id: 'completed-sessions',
+    targetSelector: '#tour-completed-sessions',
+    title: 'Completed Sessions',
+    content: 'Review your completed mentorship sessions and learning history here.',
+    route: 'DYNAMIC_SESSIONS',
+    stepNumber: 5,
+    totalSteps: 5,
+  },
+];
+
+const TourContext = createContext<TourContextType | undefined>(undefined);
+
+const TOUR_COMPLETED_KEY = 'zuvy_dashboard_tour_completed';
+
+export const TourProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { studentData } = useStudentData();
+  
+  const [isOpen, setIsOpen] = useState(false);
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [activeElementRect, setActiveElementRect] = useState<DOMRect | null>(null);
+  const [isTourCompleted, setIsTourCompleted] = useState(false);
+
+  // Check initial completion status from localStorage
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const completed = localStorage.getItem(TOUR_COMPLETED_KEY);
+      setIsTourCompleted(completed === 'true');
+    }
+  }, []);
+
+  const startTour = useCallback((fromStepIndex: number = 0) => {
+    setCurrentStepIndex(fromStepIndex);
+    setIsOpen(true);
+  }, []);
+
+  const skipTour = useCallback(() => {
+    setIsOpen(false);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(TOUR_COMPLETED_KEY, 'true');
+      setIsTourCompleted(true);
+    }
+  }, []);
+
+  const finishTour = useCallback(() => {
+    setIsOpen(false);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(TOUR_COMPLETED_KEY, 'true');
+      setIsTourCompleted(true);
+    }
+  }, []);
+
+  const resetTour = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(TOUR_COMPLETED_KEY);
+      setIsTourCompleted(false);
+    }
+    startTour();
+  }, [startTour]);
+
+  // Resolves placeholder route tokens to actual route paths dynamically based on student enrollment
+  const getActualRoute = useCallback((stepRoute: string | undefined) => {
+    if (!stepRoute) return '';
+
+    const activeBootcamp = studentData?.inProgressBootcamps?.[0];
+    const bootcampId = activeBootcamp?.id;
+    const orgId = activeBootcamp?.organizationId;
+
+    if (stepRoute === 'DYNAMIC_COURSE_SYLLABUS') {
+      return bootcampId && orgId
+        ? `/student/course/${bootcampId}/org/${orgId}`
+        : '/student';
+    }
+    if (stepRoute === 'DYNAMIC_MENTORS') {
+      return bootcampId
+        ? `/student/mentors?courseId=${bootcampId}`
+        : '/student/mentors';
+    }
+    if (stepRoute === 'DYNAMIC_SESSIONS') {
+      return bootcampId
+        ? `/student/sessions?courseId=${bootcampId}`
+        : '/student/sessions';
+    }
+    return stepRoute;
+  }, [studentData]);
+
+  const navigateToStepRoute = useCallback((step: TourStepConfig) => {
+    const actualRoute = getActualRoute(step.route);
+    if (actualRoute) {
+      const getPathOnly = (url: string) => url.split('?')[0];
+      if (getPathOnly(pathname) !== getPathOnly(actualRoute)) {
+        router.push(actualRoute);
+      }
+    }
+  }, [pathname, router, getActualRoute]);
+
+  const nextStep = useCallback(() => {
+    if (currentStepIndex < TOUR_STEPS.length - 1) {
+      const nextIndex = currentStepIndex + 1;
+      setActiveElementRect(null);
+      setCurrentStepIndex(nextIndex);
+      navigateToStepRoute(TOUR_STEPS[nextIndex]);
+    } else {
+      finishTour();
+    }
+  }, [currentStepIndex, navigateToStepRoute, finishTour]);
+
+  const prevStep = useCallback(() => {
+    if (currentStepIndex > 0) {
+      const prevIndex = currentStepIndex - 1;
+      setActiveElementRect(null);
+      setCurrentStepIndex(prevIndex);
+      navigateToStepRoute(TOUR_STEPS[prevIndex]);
+    }
+  }, [currentStepIndex, navigateToStepRoute]);
+
+  // Track target element size & position updates
+  const updateActiveRect = useCallback(() => {
+    if (!isOpen) return;
+    
+    const step = TOUR_STEPS[currentStepIndex];
+    if (!step) return;
+
+    const element = document.querySelector(step.targetSelector);
+    if (element) {
+      setActiveElementRect(element.getBoundingClientRect());
+    } else {
+      setActiveElementRect(null);
+    }
+  }, [isOpen, currentStepIndex]);
+
+  // Handle polling for dynamic elements (especially during routing)
+  useEffect(() => {
+    if (!isOpen) {
+      setActiveElementRect(null);
+      return;
+    }
+
+    const step = TOUR_STEPS[currentStepIndex];
+    if (!step) return;
+
+    // Check if we are on the correct route first
+    const actualRoute = getActualRoute(step.route);
+    const getPathOnly = (url: string) => url.split('?')[0];
+    if (actualRoute && getPathOnly(pathname) !== getPathOnly(actualRoute)) {
+      setActiveElementRect(null); // Keep overlay solid during route transition
+      return;
+    }
+
+    let attempts = 0;
+    const maxAttempts = 30; // 3 seconds max polling time
+
+    const interval = setInterval(() => {
+      const element = document.querySelector(step.targetSelector);
+      if (element) {
+        clearInterval(interval);
+        
+        // Element found, record bounds
+        setActiveElementRect(element.getBoundingClientRect());
+        
+        // Scroll target element to center smoothly if needed
+        element.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+          inline: 'nearest',
+        });
+      } else {
+        attempts++;
+        if (attempts >= maxAttempts) {
+          clearInterval(interval);
+          console.warn(`[Tour] target selector "${step.targetSelector}" not found after 3s.`);
+          setActiveElementRect(null); // Fallback to centered modal tooltip
+        }
+      }
+    }, 100);
+
+    return () => clearInterval(interval);
+  }, [currentStepIndex, pathname, isOpen, getActualRoute]);
+
+  // Event listeners for window resize / scroll (with capturing) to update bounding rects
+  useEffect(() => {
+    if (!isOpen) return;
+
+    window.addEventListener('resize', updateActiveRect);
+    window.addEventListener('scroll', updateActiveRect, { capture: true });
+
+    return () => {
+      window.removeEventListener('resize', updateActiveRect);
+      window.removeEventListener('scroll', updateActiveRect, { capture: true });
+    };
+  }, [isOpen, updateActiveRect]);
+
+  // Keyboard navigation shortcuts
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        skipTour();
+      } else if (e.key === 'ArrowRight') {
+        // Prevent action on inputs
+        if (document.activeElement?.tagName === 'INPUT' || document.activeElement?.tagName === 'TEXTAREA') {
+          return;
+        }
+        nextStep();
+      } else if (e.key === 'ArrowLeft') {
+        if (document.activeElement?.tagName === 'INPUT' || document.activeElement?.tagName === 'TEXTAREA') {
+          return;
+        }
+        prevStep();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, nextStep, prevStep, skipTour]);
+
+  return (
+    <TourContext.Provider
+      value={{
+        isOpen,
+        currentStepIndex,
+        steps: TOUR_STEPS,
+        activeElementRect,
+        isTourCompleted,
+        startTour,
+        nextStep,
+        prevStep,
+        skipTour,
+        finishTour,
+        resetTour,
+      }}
+    >
+      {children}
+    </TourContext.Provider>
+  );
+};
+
+export const useTour = () => {
+  const context = useContext(TourContext);
+  if (context === undefined) {
+    throw new Error('useTour must be used within a TourProvider');
+  }
+  return context;
+};

--- a/src/app/student/_components/guided-tour/TourOverlay.tsx
+++ b/src/app/student/_components/guided-tour/TourOverlay.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React from 'react';
+import { useTour } from './TourContext';
+
+export const TourOverlay: React.FC = () => {
+  const { isOpen, activeElementRect } = useTour();
+
+  if (!isOpen) return null;
+
+  const hasHighlight = activeElementRect !== null;
+  const x = hasHighlight ? activeElementRect.left - 6 : 0;
+  const y = hasHighlight ? activeElementRect.top - 6 : 0;
+  const width = hasHighlight ? activeElementRect.width + 12 : 0;
+  const height = hasHighlight ? activeElementRect.height + 12 : 0;
+  const rx = 10; // Rounded corners for high-quality aesthetics
+
+  return (
+    <div className="fixed inset-0 pointer-events-none z-[9999] transition-opacity duration-300">
+      <svg className="w-full h-full pointer-events-auto">
+        <defs>
+          <mask id="tour-spotlight-mask">
+            {/* White fill means keep overlay opaque */}
+            <rect x="0" y="0" width="100%" height="100%" fill="white" />
+            {/* Black cutout creates the transparent hole */}
+            {hasHighlight && (
+              <rect
+                x={x}
+                y={y}
+                width={width}
+                height={height}
+                rx={rx}
+                ry={rx}
+                fill="black"
+                style={{
+                  transition: 'x 0.3s ease-out, y 0.3s ease-out, width 0.3s ease-out, height 0.3s ease-out',
+                }}
+              />
+            )}
+          </mask>
+        </defs>
+
+        {/* Translucent overlay mask */}
+        <rect
+          x="0"
+          y="0"
+          width="100%"
+          height="100%"
+          fill="rgba(15, 23, 42, 0.65)" // Sleek slate dark mode tint for overlay
+          className="backdrop-blur-[1px]" // Subtle backdrop blur to stand out
+          mask="url(#tour-spotlight-mask)"
+        />
+      </svg>
+    </div>
+  );
+};

--- a/src/app/student/_components/guided-tour/TourTooltip.tsx
+++ b/src/app/student/_components/guided-tour/TourTooltip.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useTour } from './TourContext';
+import { Button } from '@/components/ui/button';
+import { X, Sparkles } from 'lucide-react';
+import { usePathname } from 'next/navigation';
+
+export const TourTooltip: React.FC = () => {
+  const {
+    isOpen,
+    currentStepIndex,
+    steps,
+    activeElementRect,
+    nextStep,
+    prevStep,
+    skipTour,
+    finishTour,
+  } = useTour();
+
+  const pathname = usePathname();
+
+  const [coords, setCoords] = useState<{ top: number; left: number; placement: 'top' | 'bottom' }>({
+    top: 0,
+    left: 0,
+    placement: 'bottom',
+  });
+
+  const step = steps[currentStepIndex];
+  const isLastStep = currentStepIndex === steps.length - 1;
+
+  // Resolve only static routes (skip DYNAMIC_ tokens — TourContext handles those)
+  const resolvedRoute =
+    step?.route && !step.route.startsWith('DYNAMIC_') ? step.route : null;
+
+  // Only hide during active route transition (we're on a different page than expected)
+  const currentPath = pathname.split('?')[0];
+  const expectedPath = resolvedRoute ? resolvedRoute.split('?')[0] : null;
+  const isTransitioning = expectedPath !== null && currentPath !== expectedPath;
+
+  useEffect(() => {
+    if (!activeElementRect) return;
+
+    const tooltipWidth = 320;
+    const tooltipHeight = 190;
+    const padding = 16;
+    const arrowHeight = 8;
+
+    const target = activeElementRect;
+
+    let top = target.bottom + arrowHeight + 8;
+    let left = target.left + (target.width - tooltipWidth) / 2;
+    let placement: 'top' | 'bottom' = 'bottom';
+
+    if (left < padding) {
+      left = padding;
+    } else if (left + tooltipWidth > window.innerWidth - padding) {
+      left = window.innerWidth - tooltipWidth - padding;
+    }
+
+    if (top + tooltipHeight > window.innerHeight - padding) {
+      if (target.top - tooltipHeight - arrowHeight - 8 > padding) {
+        top = target.top - tooltipHeight - arrowHeight - 8;
+        placement = 'top';
+      }
+    }
+
+    setCoords({ top, left, placement });
+  }, [activeElementRect]);
+
+  if (!isOpen || !step) return null;
+
+  // Hide only while navigating to a different page
+  if (isTransitioning) return null;
+
+  // Fallback: target element not found — render centered modal
+  if (!activeElementRect) {
+    return (
+      <div className="fixed inset-0 flex items-center justify-center p-4 z-[10000] pointer-events-none">
+        <div className="w-[340px] p-6 rounded-2xl bg-card border border-border shadow-2xl animate-in fade-in zoom-in-95 duration-200 pointer-events-auto">
+          <div className="flex items-center justify-between mb-4">
+            <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-primary px-2.5 py-0.5 rounded-full bg-primary-light/50">
+              <Sparkles className="w-3.5 h-3.5 text-primary" />
+              Onboarding Tour: {step.stepNumber}/{step.totalSteps}
+            </span>
+            <button
+              onClick={skipTour}
+              className="text-muted-foreground hover:text-foreground transition-colors p-1"
+              aria-label="Skip onboarding tour"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+
+          <h3 className="text-lg font-bold text-foreground mb-2 text-left">{step.title}</h3>
+          <p className="text-sm text-muted-foreground mb-6 leading-relaxed text-left">{step.content}</p>
+
+          <div className="flex items-center justify-between pt-2 border-t border-border">
+            <button
+              onClick={skipTour}
+              className="text-xs text-muted-foreground hover:text-foreground font-semibold"
+            >
+              Skip Tour
+            </button>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={prevStep}
+                disabled={currentStepIndex === 0}
+                className="h-8 text-xs font-medium border-border"
+              >
+                Back
+              </Button>
+              {isLastStep ? (
+                <Button
+                  size="sm"
+                  onClick={finishTour}
+                  className="h-8 text-xs bg-primary text-primary-foreground hover:bg-primary-dark font-semibold px-3"
+                >
+                  Finish
+                </Button>
+              ) : (
+                <Button
+                  size="sm"
+                  onClick={nextStep}
+                  className="h-8 text-xs bg-primary text-primary-foreground hover:bg-primary-dark font-semibold px-3"
+                >
+                  Next
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: coords.top,
+        left: coords.left,
+      }}
+      className="w-[320px] p-5 rounded-2xl bg-card border border-border shadow-2xl z-[10000] animate-in fade-in slide-in-from-top-2 duration-300 pointer-events-auto"
+    >
+      <div
+        className={`absolute w-3 h-3 bg-card border-border rotate-45 z-[-1] ${
+          coords.placement === 'bottom'
+            ? '-top-1.5 left-1/2 -translate-x-1/2 border-l border-t'
+            : '-bottom-1.5 left-1/2 -translate-x-1/2 border-r border-b'
+        }`}
+      />
+
+      <div className="flex items-center justify-between mb-3">
+        <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-primary px-2.5 py-0.5 rounded-full bg-primary-light/50">
+          {step.stepNumber}/{step.totalSteps}
+        </span>
+        <button
+          onClick={skipTour}
+          className="text-muted-foreground hover:text-foreground transition-colors p-1"
+          aria-label="Skip onboarding tour"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      <h3 className="text-base font-bold text-foreground mb-1.5 text-left">{step.title}</h3>
+      <p className="text-[13px] text-muted-foreground mb-5 leading-relaxed text-left">{step.content}</p>
+
+      <div className="flex items-center justify-between pt-3 border-t border-border">
+        <button
+          onClick={skipTour}
+          className="text-xs text-muted-foreground hover:text-foreground font-semibold"
+        >
+          Skip Tour
+        </button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={prevStep}
+            disabled={currentStepIndex === 0}
+            className="h-8 text-xs font-semibold border-border disabled:opacity-50"
+          >
+            Back
+          </Button>
+          {isLastStep ? (
+            <Button
+              size="sm"
+              onClick={finishTour}
+              className="h-8 text-xs bg-primary text-primary-foreground hover:bg-primary-dark font-semibold px-3"
+            >
+              Finish
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              onClick={nextStep}
+              className="h-8 text-xs bg-primary text-primary-foreground hover:bg-primary-dark font-semibold px-3"
+            >
+              Next
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/app/student/_components/guided-tour/index.ts
+++ b/src/app/student/_components/guided-tour/index.ts
@@ -1,0 +1,4 @@
+export { TourProvider, useTour } from './TourContext';
+export { TourOverlay } from './TourOverlay';
+export { TourTooltip } from './TourTooltip';
+export type { TourStepConfig } from './TourContext';

--- a/src/app/student/_pages/ProfilePage.tsx
+++ b/src/app/student/_pages/ProfilePage.tsx
@@ -1607,7 +1607,7 @@ export const OnboardingPage: React.FC<OnboardingPageProps> = ({ userEmail = '', 
         <div className="mb-8">
           <div className="flex items-start justify-between mb-6">
             <div>
-              <h1 className="text-3xl md:text-4xl font-bold mb-2">Setup your Profile</h1>
+              <h1 id="tour-profile" className="text-3xl md:text-4xl font-bold mb-2">Setup your Profile</h1>
               <p className="text-muted-foreground">Complete these steps to unlock job applications.</p>
             </div>
             <div className="px-3 py-1 bg-primary/10 text-primary rounded-lg text-sm font-medium">

--- a/src/app/student/_pages/StudentDashboard.tsx
+++ b/src/app/student/_pages/StudentDashboard.tsx
@@ -292,7 +292,7 @@ const StudentDashboard = () => {
 
 
             <div className="mb-6">
-              <h2 className="text-2xl font-heading text-left font-semibold mb-6">My Courses</h2>
+              <h2 className="text-2xl font-heading text-left font-semibold mb-6" id="tour-courses">My Courses</h2>
 
               <div className="flex gap-3 mb-6">
                 <Button

--- a/src/app/student/layout.tsx
+++ b/src/app/student/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 import Header from './_components/Header'
+import { TourProvider, TourOverlay, TourTooltip } from './_components/guided-tour';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useEffect, Suspense, useState } from 'react';
 import { getUser, useThemeStore } from '@/store/store';
@@ -90,22 +91,26 @@ function StudentLayoutContent({
     };
 
     return (
-        <div className="h-screen overflow-hidden bg-background flex flex-col font-manrope">
+        <TourProvider>
+            <div className="h-screen overflow-hidden bg-background flex flex-col font-manrope">
 
-            <ThemeInitializer />
-            <div className="sticky top-0 z-50">
-                <ZoeBanner 
-                    isVisible={showZoeBanner}
-                    onDismiss={handleDismissBanner}
-                    onStartInterview={handleStartInterview}
-                    onGiveFeedback={handleGiveFeedback}
-                />
-                {!hideHeader && !isOnCourseModulePage && <Header />}
+                <ThemeInitializer />
+                <div className="sticky top-0 z-50">
+                    <ZoeBanner 
+                        isVisible={showZoeBanner}
+                        onDismiss={handleDismissBanner}
+                        onStartInterview={handleStartInterview}
+                        onGiveFeedback={handleGiveFeedback}
+                    />
+                    {!hideHeader && !isOnCourseModulePage && <Header />}
+                </div>
+                <main id="main-scroll-container" className="flex-1 overflow-y-auto">
+                    {children}
+                </main>
+                <TourOverlay />
+                <TourTooltip />
             </div>
-            <main id="main-scroll-container" className="flex-1 overflow-y-auto">
-                {children}
-            </main>
-        </div>
+        </TourProvider>
     )
 }
 

--- a/src/app/student/mentors/page.tsx
+++ b/src/app/student/mentors/page.tsx
@@ -265,7 +265,7 @@ export default function MentorsPage() {
                 <p className="text-sm text-gray-500">No mentors available right now.</p>
             ) : (
                 <div className="grid w-full grid-cols-1 gap-5  md:grid-cols-2 lg:grid-cols-3">
-                    {visibleMentors.map((mentor) => {
+                    {visibleMentors.map((mentor, index) => {
                         const expertise = Array.isArray(mentor.expertise)
                             ? mentor.expertise
                             : [];
@@ -368,6 +368,7 @@ export default function MentorsPage() {
 
                         return (
                             <button
+                                id={index === 0 ? "tour-mentor-card" : undefined}
                                 key={`${mentor.userId}-${mentor.organizationId}`}
                                 type="button"
                                 onClick={() => handleMentorClick(mentor)}

--- a/src/app/student/page.tsx
+++ b/src/app/student/page.tsx
@@ -3,13 +3,13 @@
 import { useState, useEffect } from 'react';
 import StudentDashboard from './_pages/StudentDashboard';
 import ZoeFlashScreen from '../_components/ZoeFlashScreen';
-// import FlashAnnouncementDialog from '../_components/FlashAnnouncement';
-
+import { useTour } from './_components/guided-tour';
 
 
 const Page = () => {
   const [showAnnouncement, setShowAnnouncement] = useState<boolean>(false);
   const [isClient, setIsClient] = useState<boolean>(false);
+  const { startTour, isTourCompleted } = useTour();
 
   useEffect(() => {
     setIsClient(true);
@@ -18,6 +18,12 @@ const Page = () => {
       setShowAnnouncement(!!isLoginFirst);
     }
   }, []);
+
+  useEffect(() => {
+    if (isClient && !showAnnouncement && !isTourCompleted) {
+      startTour(1); // Start from Courses step (index 1) since we're on /student
+    }
+  }, [isClient, showAnnouncement, isTourCompleted, startTour]);
 
   const handleCloseAnnouncement = () => {
     setShowAnnouncement(false);

--- a/src/app/student/profile/page.tsx
+++ b/src/app/student/profile/page.tsx
@@ -3,11 +3,26 @@ import ProfilePage from '@/app/student/_pages/ProfilePage';
 import EditProfilePage from '@/app/student/_pages/EditProfilePage';
 import { useOnboardingStorage } from '@/hooks/use-profile';
 import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useTour } from '@/app/student/_components/guided-tour';
 
 export default function Page() {
   const searchParams = useSearchParams();
   const { onboardingData, isLoading } = useOnboardingStorage();
   const forceEditMode = searchParams.get('mode') === 'edit';
+  const { startTour, isTourCompleted } = useTour();
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isClient) return;
+    if (!isTourCompleted) {
+      startTour();
+    }
+  }, [isClient, isTourCompleted, startTour]);
 
   if (isLoading) {
     return null;
@@ -19,4 +34,3 @@ export default function Page() {
 
   return <ProfilePage />;
 }
-

--- a/src/app/student/sessions/page.tsx
+++ b/src/app/student/sessions/page.tsx
@@ -240,6 +240,7 @@ export default function MySessions() {
       <div className="flex items-center  rounded-full p-1 w-fit gap-3">
 
         <TabButton
+          id="tour-upcoming-sessions"
           active={activeTab === "upcoming"}
           icon={CalendarDays}
           label="Upcoming"
@@ -248,6 +249,7 @@ export default function MySessions() {
         />
 
         <TabButton
+          id="tour-completed-sessions"
           active={activeTab === "completed"}
           icon={CheckCircle2}
           label="Completed"
@@ -729,6 +731,7 @@ function StatCard({
 }
 
 function TabButton({
+  id,
   icon: Icon,
   label,
   count,
@@ -737,6 +740,7 @@ function TabButton({
 }: any) {
   return (
     <button
+      id={id}
       onClick={onClick}
       className={cn(
         "flex h-9 items-center gap-1.5 rounded-full border px-4 text-sm font-medium transition-all duration-200",


### PR DESCRIPTION
## Overview
Implemented a guided onboarding tour for students after login to help them navigate the platform.

## Changes Made
- Added interactive tooltip-based onboarding tour.
- Guided students through Mentor Sessions page.
- Added guidance for session booking flow.
- Added guidance for My Sessions page.
- Implemented Next and Back navigation between steps.
- Added Skip and Finish actions.
- Added step progress tracking.
- Highlighted relevant UI elements during the tour.
- Stored tour completion status to prevent showing it repeatedly.