### PR TITLE
feat: add All Sessions tab to student sessions page

### DIFF
--- a/src/app/student/_components/MentorBookingDrawer.tsx
+++ b/src/app/student/_components/MentorBookingDrawer.tsx
@@ -397,14 +397,13 @@ export default function MentorBookingDrawer({
                       ) : null}
                     </div>
                   )}
-
                   <Button
-                    onClick={handleBook}
-                    disabled={!canBook}
-                    className="h-10 w-full bg-green-800 text-white hover:bg-green-900 text-sm font-medium cursor-not-allowed"
-                  >
-                    {isBooking ? "Booking..." : "Book this Session"}
-                  </Button>
+                      onClick={handleBook}
+                      disabled={!canBook}
+                      className="h-10 w-full bg-green-800 text-white text-sm font-medium cursor-pointer hover:bg-green-900 disabled:cursor-not-allowed  disabled:hover:bg-green-800"
+                    >
+                      {isBooking ? "Booking..." : "Book this Session"}
+                    </Button>
                 </div>
               </div>
             )}

--- a/src/app/student/_components/guided-tour/TourContext.tsx
+++ b/src/app/student/_components/guided-tour/TourContext.tsx
@@ -36,7 +36,7 @@ const TOUR_STEPS: TourStepConfig[] = [
     content: 'Manage your profile information, update personal details, and access account settings from here.',
     route: '/student/profile',
     stepNumber: 1,
-    totalSteps: 8,
+    totalSteps: 9,
   },
   {
     id: 'courses',
@@ -45,7 +45,7 @@ const TOUR_STEPS: TourStepConfig[] = [
     content: 'View your enrolled courses and continue your learning journey from this section.',
     route: '/student',
     stepNumber: 2,
-    totalSteps: 8,
+    totalSteps: 9,
   },
   {
     id: 'mentorship',
@@ -54,7 +54,7 @@ const TOUR_STEPS: TourStepConfig[] = [
     content: 'Connect with mentors and receive personalized guidance to accelerate your learning and career growth.',
     route: 'DYNAMIC_COURSE_SYLLABUS',
     stepNumber: 3,
-    totalSteps: 8,
+    totalSteps: 9,
   },
   {
     id: 'browse-mentors',
@@ -63,7 +63,7 @@ const TOUR_STEPS: TourStepConfig[] = [
     content: 'Explore available mentors, view their profiles, and book mentorship sessions based on your interests and goals.',
     route: 'DYNAMIC_MENTORS',
     stepNumber: 4,
-    totalSteps: 8,
+    totalSteps: 9,
   },
   {
     id: 'book-session',
@@ -72,7 +72,7 @@ const TOUR_STEPS: TourStepConfig[] = [
     content: 'Click on any available mentor to view their available slots and book a mentorship session.',
     route: 'DYNAMIC_MENTORS',
     stepNumber: 5,
-    totalSteps: 8,
+    totalSteps: 9,
   },
   {
     id: 'my-sessions',
@@ -81,7 +81,16 @@ const TOUR_STEPS: TourStepConfig[] = [
     content: 'Track all your mentorship sessions in one place.',
     route: 'DYNAMIC_SESSIONS',
     stepNumber: 6,
-    totalSteps: 8,
+    totalSteps: 9,
+  },
+  {
+    id: 'all-sessions',
+    targetSelector: '#tour-all-sessions',
+    title: 'All Sessions',
+    content: 'View all your sessions in one place — upcoming, in progress, completed, and cancelled.',
+    route: 'DYNAMIC_SESSIONS',
+    stepNumber: 7,
+    totalSteps: 9,
   },
   {
     id: 'upcoming-sessions',
@@ -89,8 +98,8 @@ const TOUR_STEPS: TourStepConfig[] = [
     title: 'Upcoming Sessions',
     content: 'View all your upcoming booked mentorship sessions here.',
     route: 'DYNAMIC_SESSIONS',
-    stepNumber: 7,
-    totalSteps: 8,
+    stepNumber: 8,
+    totalSteps: 9,
   },
   {
     id: 'completed-sessions',
@@ -98,8 +107,8 @@ const TOUR_STEPS: TourStepConfig[] = [
     title: 'Completed Sessions',
     content: 'Review your completed mentorship sessions and learning history here.',
     route: 'DYNAMIC_SESSIONS',
-    stepNumber: 8,
-    totalSteps: 8,
+    stepNumber: 9,
+    totalSteps: 9,
   },
 ];
 

--- a/src/app/student/sessions/page.tsx
+++ b/src/app/student/sessions/page.tsx
@@ -45,7 +45,7 @@ import {
   getSessionRescheduleHref,
 } from "@/utils/studentMentorshipRoutes"
 
-type Tab = "upcoming" | "completed" | "cancelled"
+type Tab = "all" | "upcoming" | "completed" | "cancelled"
 
 const formatLifecycleValue = (value: string | null | undefined) =>
   (value || "-").replaceAll("_", " ")
@@ -151,7 +151,7 @@ export default function MySessions() {
   const courseId = searchParams.get("courseId") || ""
   const orgId = searchParams.get("orgId") || ""
   const routeContext = { courseId, orgId }
-  const [activeTab, setActiveTab] = useState<Tab>("upcoming")
+  const [activeTab, setActiveTab] = useState<Tab>("all")
   const [nowTimestamp, setNowTimestamp] = useState(() => Date.now())
   const [feedbackBookingId, setFeedbackBookingId] = useState<number | null>(null)
   const [tempRating, setTempRating] = useState(5)
@@ -217,7 +217,14 @@ export default function MySessions() {
     "cancelled"
   )
 
+  const { counts: allCounts } = useMyMentorSessions(
+    true,
+    "/student/mentor-sessions/my",
+    "all"
+  )
+
   const counts = {
+    all: Number(allCounts.total) || 0,
     upcoming: Number(upcomingCounts.upcoming) || 0,
     completed: Number(completedCounts.completed) || 0,
     cancelled: Number(cancelledCounts.cancelled) || 0,
@@ -238,6 +245,15 @@ export default function MySessions() {
       {/* TABS */}
 
       <div className="flex items-center  rounded-full p-1 w-fit gap-3">
+
+        <TabButton
+          id="tour-all-sessions"
+          active={activeTab === "all"}
+          icon={Calendar}
+          label="All"
+          count={counts.all}
+          onClick={() => setActiveTab("all")}
+        />
 
         <TabButton
           id="tour-upcoming-sessions"
@@ -291,6 +307,199 @@ export default function MySessions() {
             Retry
           </Button>
         </div>
+      ) : activeTab === "all" ? (
+        counts.all === 0 ? (
+          <Card className="rounded-3xl border">
+            <CardContent className="flex flex-col items-center justify-center py-12 text-center space-y-3">
+              <CalendarDays className="h-6 w-6 text-muted-foreground" size={36} />
+              <h1 className="font-semibold text-sm">No sessions yet</h1>
+              <p className="text-sm text-muted-foreground max-w-sm">
+                Your sessions will appear here once you book them.
+              </p>
+              <Button className="mt-4 text-sm text-white px-5 py-2 rounded-lg flex items-center gap-2" asChild>
+                <Link href={getMentorsHref(routeContext)}>
+                  <Users size={16} />
+                  Book a Session
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ) : (
+          sessions.map((session) => {
+            const lifecycle = (session.sessionLifecycleState || "").toUpperCase()
+            const isInProgress = lifecycle === "IN_PROGRESS"
+            const isCompleted = lifecycle === "COMPLETED"
+            const isCancelled = lifecycle === "CANCELLED" || session.status === "cancelled"
+            const isUpcoming = !isInProgress && !isCompleted && !isCancelled
+            const joinUrl = session.meetingLink?.trim() || ""
+            const canJoinNow = !!joinUrl && isJoinWindowOpen(session.slotStart, session.slotEnd, nowTimestamp)
+
+            const hasStudentFeedback = Boolean(
+              (session as any).studentRating ||
+              (session as any).studentFeedback ||
+              (session as any).studentFeedbackNotes ||
+              locallySubmittedFeedbackIds[session.id]
+            )
+            const studentRating = Number((session as any).studentRating || locallySubmittedFeedbackIds[session.id]?.rating || 0)
+            const studentFeedback = (session as any).studentFeedback || (session as any).studentFeedbackNotes || (session as any).studentNotes || locallySubmittedFeedbackIds[session.id]?.feedback || ""
+
+            const statusBadge = isInProgress ? (
+              <span className="inline-flex self-start items-center gap-1.5 px-3 py-1 leading-none text-xs font-medium rounded-full bg-blue-100 text-blue-700">In Progress</span>
+            ) : isCompleted ? (
+              <span className="inline-flex self-start items-center gap-1.5 px-3 py-1 leading-none text-xs font-medium rounded-full bg-green-100 text-green-700">Completed</span>
+            ) : isCancelled ? (
+              <Badge className="bg-destructive-light text-destructive">Cancelled</Badge>
+            ) : (
+              <span className="inline-flex self-start items-center gap-1.5 px-3 py-1 leading-none text-xs font-medium rounded-full bg-green-100 text-green-700">Upcoming</span>
+            )
+
+            // Cancelled card
+            if (isCancelled) {
+              return (
+                <Card key={session.id} className="rounded-2xl border shadow-sm">
+                  <CardContent className="p-6 space-y-4">
+                    <div className="flex justify-between items-start">
+                      <div className="flex gap-3 items-center">
+                        <Avatar>
+                          <AvatarFallback className="bg-primary text-primary-foreground font-bold">
+                            {getMentorAvatarFallback(session.mentorName, session.mentorUserId)}
+                          </AvatarFallback>
+                        </Avatar>
+                        <div className="min-w-0">
+                          <p className="font-semibold truncate">{getMentorDisplayName(session.mentorName, session.mentorUserId)}</p>
+                        </div>
+                      </div>
+                      {statusBadge}
+                    </div>
+                    <div className="flex gap-6 text-sm text-muted-foreground">
+                      <div className="flex items-center gap-1 text-sm"><Calendar size={14} />{formatDateOnly(session.slotStart || session.slotEnd)}</div>
+                      <div className="flex items-center gap-1 text-sm"><Clock size={14} />{formatTimeRange(session.slotStart, session.slotEnd)}</div>
+                      <div className="text-sm">Booking #{session.id}</div>
+                      <div className="text-sm">{session.status}</div>
+                    </div>
+                    <div className="border-t pt-4" />
+                    <Link href={getMentorProfileHref(session.mentorUserId, routeContext)} className="text-green-600 text-sm font-medium flex items-center gap-2">
+                      <CalendarDays size={16} />
+                      Book again with {getMentorDisplayName(session.mentorName, session.mentorUserId)} →
+                    </Link>
+                  </CardContent>
+                </Card>
+              )
+            }
+
+            // Completed card
+            if (isCompleted) {
+              return (
+                <Card key={session.id} className="rounded-2xl border shadow-sm">
+                  <CardContent className="p-6 rounded-3xl">
+                    <div className="flex justify-between items-start">
+                      <div className="flex gap-3 items-center">
+                        <Avatar>
+                          <AvatarFallback className="bg-primary text-primary-foreground font-bold">{getMentorAvatarFallback(session.mentorName, session.mentorUserId)}</AvatarFallback>
+                        </Avatar>
+                        <div className="min-w-0">
+                          <p className="font-semibold truncate">{getMentorDisplayName(session.mentorName, session.mentorUserId)}</p>
+                        </div>
+                      </div>
+                      {statusBadge}
+                    </div>
+                    <div className="flex gap-6 text-sm text-muted-foreground mt-3">
+                      <div className="flex items-center gap-1 text-sm"><Calendar size={14} />{formatDateOnly(session.slotStart || session.slotEnd)}</div>
+                      <div className="flex items-center gap-1 text-sm"><Clock size={14} />{formatTimeRange(session.slotStart, session.slotEnd)}</div>
+                      <div className="text-sm">Booking #{session.id}</div>
+                      <div className="text-sm">{session.status}</div>
+                    </div>
+                    <div className="mt-3 space-y-2 text-sm text-muted-foreground text-left">
+                      <p>Mentor rating: {typeof session.mentorRating === "number" ? session.mentorRating : "-"}</p>
+                      <p>Feedback notes: {session.mentorFeedback?.notes?.trim() || "-"}</p>
+                      <p>Areas of improvement: {session.mentorFeedback?.areasOfImprovement?.trim() || "-"}</p>
+                      <RecordingLink bookingId={session.id} />
+                    </div>
+                    {hasStudentFeedback ? (
+                      <div className="mt-4 border-t pt-4 space-y-1 text-left">
+                        <p className="text-sm font-semibold text-slate-800">Your Feedback to Mentor</p>
+                        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                          <span>Rating:</span>
+                          <div className="flex gap-0.5">
+                            {Array.from({ length: 5 }).map((_, idx) => (
+                              <Star key={idx} size={12} className={idx < studentRating ? "text-yellow-500 fill-yellow-500" : "text-gray-300"} />
+                            ))}
+                          </div>
+                        </div>
+                        {studentFeedback && <p className="text-xs text-muted-foreground italic">&ldquo;{studentFeedback}&rdquo;</p>}
+                      </div>
+                    ) : (
+                      <div className="mt-4 border-t pt-4 flex justify-end">
+                        <Button size="sm" className="bg-[#2F6B2F] hover:bg-[#204a20] text-white font-medium" onClick={() => { setFeedbackBookingId(session.id); setTempRating(5); setTempFeedback("") }}>
+                          Submit Feedback
+                        </Button>
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              )
+            }
+
+            // Upcoming + In Progress card
+            return (
+              <Card key={session.id} className="rounded-3xl">
+                <CardContent className="p-6 rounded-3xl">
+                  <div className="flex justify-between">
+                    <div className="flex gap-3 items-center">
+                      <Avatar>
+                        <AvatarFallback className="bg-primary text-primary-foreground font-bold">{getMentorAvatarFallback(session.mentorName, session.mentorUserId)}</AvatarFallback>
+                      </Avatar>
+                      <div className="min-w-0">
+                        <p className="font-semibold truncate">{getMentorDisplayName(session.mentorName, session.mentorUserId)}</p>
+                      </div>
+                    </div>
+                    {statusBadge}
+                  </div>
+                  <div className="flex gap-6 text-sm text-muted-foreground mt-3">
+                    <div className="flex items-center gap-1 text-sm"><Calendar size={14} />{formatDateOnly(session.slotStart || session.slotEnd)}</div>
+                    <div className="flex items-center gap-1 text-sm"><Clock size={14} />{formatTimeRange(session.slotStart, session.slotEnd)}</div>
+                    <div className="text-sm">Booking #{session.id}</div>
+                    <div className="text-sm">{session.status}</div>
+                  </div>
+                  {isUpcoming && (
+                    <p className="text-sm text-muted-foreground mt-2 text-left">
+                      You&apos;re all set. We&apos;ll remind you before the session.
+                    </p>
+                  )}
+                </CardContent>
+                <CardFooter className="flex gap-3 flex-wrap">
+                  {!canJoinNow && !isInProgress && !!joinUrl && (
+                    <p className="basis-full text-xs text-muted-foreground text-left">Join opens 10 min before start</p>
+                  )}
+                  <Button className="flex gap-2" asChild={canJoinNow || isInProgress} disabled={!canJoinNow && !isInProgress}>
+                    {canJoinNow || isInProgress ? (
+                      <Link href={getSessionJoinHref(session.id, joinUrl, routeContext)} target="_blank" rel="noopener noreferrer">
+                        <Video size={14} />
+                        Join Session
+                      </Link>
+                    ) : joinUrl ? (
+                      <><Video size={14} />Join Session</>
+                    ) : (
+                      <><Video size={14} />Join Unavailable</>
+                    )}
+                  </Button>
+                  {isUpcoming && (
+                    <>
+                      <Button variant="outline" asChild>
+                        <Link href={getSessionRescheduleHref(session.id, routeContext, { currentSlotId: session.slotAvailabilityId, mentorId: session.mentorUserId })}>
+                          Reschedule
+                        </Link>
+                      </Button>
+                      <Button variant="outline" asChild>
+                        <Link href={getSessionCancelHref(session.id, routeContext)}>Cancel</Link>
+                      </Button>
+                    </>
+                  )}
+                </CardFooter>
+              </Card>
+            )
+          })
+        )
       ) : activeTab === "cancelled" && counts.cancelled > 0 ? (
         sessions.map((session) => (
           <Card key={session.id} className="rounded-2xl border shadow-sm">


### PR DESCRIPTION
Added a new "All" tab in the Student Sessions page to provide a complete view of all sessions in one place.
The All tab now displays all session statuses:
  - upcoming
  - completed
  - cancelled
  - in_progress
- Existing tabs (Upcoming, Completed, Cancelled) remain unchanged
Fixed Book Session button hover behavior.

