### PR TITLE
fix: update onboarding tour navigation and visibility logic

### DIFF
--- a/src/app/auth/login/_components/LoginPage.tsx
+++ b/src/app/auth/login/_components/LoginPage.tsx
@@ -228,7 +228,12 @@ const handleGoogleSuccess = async (
                     title: 'Login Successful',
                     description: 'Welcome to Zuvy Dashboard',
                 })
-                localStorage.setItem('isLoginFirst' , 'true')
+                
+                if (response.data.showTooltip) {
+                    localStorage.setItem('isLoginFirst', 'true')
+                } else {
+                    localStorage.removeItem('isLoginFirst')
+                }
 
                 // Handle redirects based on user role
                 const redirectedUrl = localStorage.getItem('redirectedUrl')

--- a/src/app/auth/login/_components/componentLogin.ts
+++ b/src/app/auth/login/_components/componentLogin.ts
@@ -28,6 +28,7 @@ export interface User {
 export interface AuthResponse {
   access_token: string;
   refresh_token: string;
+  showTooltip?: boolean;
   user: User;
 }
 

--- a/src/app/student/_components/guided-tour/TourContext.tsx
+++ b/src/app/student/_components/guided-tour/TourContext.tsx
@@ -3,6 +3,8 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { useStudentData } from '@/hooks/useStudentData';
+import { useOnboardingStorage } from '@/hooks/use-profile';
+import { api } from '@/utils/axios.config';
 
 export interface TourStepConfig {
   id: string;
@@ -120,11 +122,69 @@ export const TourProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const router = useRouter();
   const pathname = usePathname();
   const { studentData } = useStudentData();
-  
+  const { onboardingData } = useOnboardingStorage();
+
   const [isOpen, setIsOpen] = useState(false);
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
   const [activeElementRect, setActiveElementRect] = useState<DOMRect | null>(null);
   const [isTourCompleted, setIsTourCompleted] = useState(false);
+  const [hasMentorshipEnabled, setHasMentorshipEnabled] = useState<boolean | null>(null);
+
+  // Fetch settings for all student bootcamps to check if mentorship is enabled
+  useEffect(() => {
+    if (!studentData) return;
+
+    const bootcampIds = Array.from(new Set([
+      ...(studentData.inProgressBootcamps || []).map(b => b.id),
+      ...(studentData.completedBootcamps || []).map(b => b.id)
+    ]));
+
+    if (bootcampIds.length === 0) {
+      setHasMentorshipEnabled(false);
+      return;
+    }
+
+    let isMounted = true;
+    const checkMentorship = async () => {
+      try {
+        const results = await Promise.all(
+          bootcampIds.map(id => api.get(`/tracking/latestUpdatedCourse?bootcampId=${id}`).catch(() => null))
+        );
+
+        const anyMentorshipEnabled = results.some(res => {
+          if (!res || !res.data) return false;
+          return res.data.mentorshipEnabled === true;
+        });
+
+        if (isMounted) {
+          setHasMentorshipEnabled(anyMentorshipEnabled);
+        }
+      } catch (err) {
+        console.error('Error checking mentorship settings:', err);
+        if (isMounted) {
+          setHasMentorshipEnabled(false);
+        }
+      }
+    };
+
+    checkMentorship();
+    return () => {
+      isMounted = false;
+    };
+  }, [studentData]);
+
+  // Dynamically filter tour steps based on mentorship settings
+  const steps = React.useMemo(() => {
+    const filtered = hasMentorshipEnabled === true
+      ? TOUR_STEPS
+      : TOUR_STEPS.filter(step => step.id === 'profile' || step.id === 'courses');
+
+    return filtered.map((step, index) => ({
+      ...step,
+      stepNumber: index + 1,
+      totalSteps: filtered.length,
+    }));
+  }, [hasMentorshipEnabled]);
 
   // Check initial completion status from localStorage
   useEffect(() => {
@@ -139,7 +199,7 @@ export const TourProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setIsOpen(true);
   }, []);
 
-  const skipTour = useCallback(() => {
+  const skipTour = useCallback(async () => {
     setIsOpen(false);
     if (typeof window !== 'undefined') {
       localStorage.setItem(TOUR_COMPLETED_KEY, 'true');
@@ -147,13 +207,48 @@ export const TourProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   }, []);
 
-  const finishTour = useCallback(() => {
+  const finishTour = useCallback(async () => {
     setIsOpen(false);
+    
     if (typeof window !== 'undefined') {
       localStorage.setItem(TOUR_COMPLETED_KEY, 'true');
       setIsTourCompleted(true);
     }
-  }, []);
+
+    try {
+      // Check actual backend profile strength to avoid stale localStorage data
+      const res = await api.get('/learner-profile/strength');
+      const isComplete = 
+        res.data?.isProfileComplete === true || 
+        res.data?.data?.isProfileComplete === true || 
+        res.data?.profileCompletion === 100;
+        
+      if (isComplete) {
+        router.push('/student');
+      } else {
+        router.push('/student/profile');
+      }
+    } catch (err) {
+      console.error('Error fetching profile strength during finishTour:', err);
+      // Fallback to local storage
+      let isCompleted = onboardingData?.isCompleted;
+      if (typeof window !== 'undefined') {
+        const stored = localStorage.getItem('zuvy_onboarding_data');
+        if (stored) {
+          try {
+            const parsedData = JSON.parse(stored);
+            isCompleted = parsedData.isCompleted;
+          } catch (e) {}
+        }
+      }
+
+      if (isCompleted) {
+        router.push('/student');
+      } else {
+        router.push('/student/profile');
+      }
+    }
+  }, [onboardingData, router]);
 
   const resetTour = useCallback(() => {
     if (typeof window !== 'undefined') {
@@ -234,30 +329,30 @@ export const TourProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, [studentData, getActualRoute, pathname, router]);
 
   const nextStep = useCallback(() => {
-    if (currentStepIndex < TOUR_STEPS.length - 1) {
+    if (currentStepIndex < steps.length - 1) {
       const nextIndex = currentStepIndex + 1;
       setActiveElementRect(null);
       setCurrentStepIndex(nextIndex);
-      navigateToStepRoute(TOUR_STEPS[nextIndex]);
+      navigateToStepRoute(steps[nextIndex]);
     } else {
       finishTour();
     }
-  }, [currentStepIndex, navigateToStepRoute, finishTour]);
+  }, [currentStepIndex, steps, navigateToStepRoute, finishTour]);
 
   const prevStep = useCallback(() => {
     if (currentStepIndex > 0) {
       const prevIndex = currentStepIndex - 1;
       setActiveElementRect(null);
       setCurrentStepIndex(prevIndex);
-      navigateToStepRoute(TOUR_STEPS[prevIndex]);
+      navigateToStepRoute(steps[prevIndex]);
     }
-  }, [currentStepIndex, navigateToStepRoute]);
+  }, [currentStepIndex, steps, navigateToStepRoute]);
 
   // Track target element size & position updates
   const updateActiveRect = useCallback(() => {
     if (!isOpen) return;
-    
-    const step = TOUR_STEPS[currentStepIndex];
+
+    const step = steps[currentStepIndex];
     if (!step) return;
 
     const element = document.querySelector(step.targetSelector);
@@ -266,7 +361,7 @@ export const TourProvider: React.FC<{ children: React.ReactNode }> = ({ children
     } else {
       setActiveElementRect(null);
     }
-  }, [isOpen, currentStepIndex]);
+  }, [isOpen, currentStepIndex, steps]);
 
   // Handle polling for dynamic elements (especially during routing)
   useEffect(() => {
@@ -275,7 +370,7 @@ export const TourProvider: React.FC<{ children: React.ReactNode }> = ({ children
       return;
     }
 
-    const step = TOUR_STEPS[currentStepIndex];
+    const step = steps[currentStepIndex];
     if (!step) return;
 
     // Use ref so studentData loading mid-tour doesn't restart polling
@@ -312,7 +407,7 @@ export const TourProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }, 100);
 
     return () => clearInterval(interval);
-  }, [currentStepIndex, pathname, isOpen]); // removed getActualRoute — using stable ref instead
+  }, [currentStepIndex, pathname, isOpen, steps]); // removed getActualRoute — using stable ref instead
 
   // Event listeners for window resize / scroll (with capturing) to update bounding rects
   useEffect(() => {
@@ -357,7 +452,7 @@ export const TourProvider: React.FC<{ children: React.ReactNode }> = ({ children
       value={{
         isOpen,
         currentStepIndex,
-        steps: TOUR_STEPS,
+        steps,
         activeElementRect,
         isTourCompleted,
         startTour,

--- a/src/app/student/page.tsx
+++ b/src/app/student/page.tsx
@@ -1,30 +1,42 @@
 'use client';
 
 import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import StudentDashboard from './_pages/StudentDashboard';
 // import ZoeFlashScreen from '../_components/ZoeFlashScreen';
 import { useTour } from './_components/guided-tour';
+import { useOnboardingStorage } from '@/hooks/use-profile';
 
 const Page = () => {
-  const { startTour, isTourCompleted } = useTour();
+  const router = useRouter();
+  const { startTour, isTourCompleted, isOpen } = useTour();
+  const { onboardingData, isLoading } = useOnboardingStorage();
 
+  // Route guard: Redirect to profile page if profile is incomplete
   useEffect(() => {
+    if (isLoading) return;
+    if (isOpen || isTourCompleted) return; // Bypass if tour is active or was just completed/skipped
+    if (onboardingData && !onboardingData.isCompleted) {
+      router.push('/student/profile');
+    }
+  }, [onboardingData, isLoading, router, isOpen, isTourCompleted]);
+
+  // Start guided tour if necessary and profile is completed
+  useEffect(() => {
+    if (isLoading) return;
+    if (onboardingData && !onboardingData.isCompleted) return;
+
     if (isTourCompleted) return;
     const isLoginFirst = localStorage.getItem('isLoginFirst');
     if (!isLoginFirst) return;
     localStorage.removeItem('isLoginFirst');
     startTour(1);
-  }, [isTourCompleted, startTour]);
+  }, [isTourCompleted, startTour, onboardingData, isLoading]);
 
-  // const handleCloseAnnouncement = () => {
-  //   localStorage.removeItem('isLoginFirst');
-  //   if (!isTourCompleted) startTour(1);
-  // };
-
-  // const handleStartInterview = () => {
-  //   localStorage.removeItem('isLoginFirst');
-  //   if (!isTourCompleted) startTour(1);
-  // };
+  // Return null during loading or redirecting to prevent UI flash (bypass during tour)
+  if (isLoading || (!isOpen && !isTourCompleted && onboardingData && !onboardingData.isCompleted)) {
+    return null;
+  }
 
   return (
     <div>

--- a/src/app/student/profile/page.tsx
+++ b/src/app/student/profile/page.tsx
@@ -2,23 +2,36 @@
 import ProfilePage from '@/app/student/_pages/ProfilePage';
 import EditProfilePage from '@/app/student/_pages/EditProfilePage';
 import { useOnboardingStorage } from '@/hooks/use-profile';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useTour } from '@/app/student/_components/guided-tour';
 
 export default function Page() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const { onboardingData, isLoading } = useOnboardingStorage();
   const forceEditMode = searchParams.get('mode') === 'edit';
-  const { startTour, isTourCompleted } = useTour();
+  const { startTour, isTourCompleted, isOpen } = useTour();
   const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
     setIsClient(true);
   }, []);
 
+  // Route guard: Redirect to dashboard if profile is complete (and not in force edit mode)
   useEffect(() => {
-    if (!isClient) return;
+    if (!isClient || isLoading) return;
+    if (isOpen) return; // Bypass route guard if guided tour is active
+    if (onboardingData?.isCompleted && !forceEditMode) {
+      router.push('/student');
+    }
+  }, [isClient, isLoading, onboardingData, forceEditMode, router, isOpen]);
+
+  // Start guided tour if necessary and profile is incomplete
+  useEffect(() => {
+    if (!isClient || isLoading) return;
+    if (onboardingData?.isCompleted && !forceEditMode) return;
+
     if (!isTourCompleted) {
       const isLoginFirst = localStorage.getItem('isLoginFirst');
       if (isLoginFirst) {
@@ -26,9 +39,14 @@ export default function Page() {
         startTour();
       }
     }
-  }, [isClient, isTourCompleted, startTour]);
+  }, [isClient, isLoading, isTourCompleted, startTour, onboardingData, forceEditMode]);
 
   if (isLoading) {
+    return null;
+  }
+
+  // Prevent flashing profile page while redirecting complete profile to dashboard (bypass during tour)
+  if (!isOpen && onboardingData?.isCompleted && !forceEditMode) {
     return null;
   }
 


### PR DESCRIPTION
Implemented improvements to the student onboarding tour flow and navigation:

- Redirect the student to the dashboard when the onboarding tour is completed.
- Updated post-tour redirection logic:
  - Redirect to the dashboard if the student profile is complete.
  - Redirect to the profile page if the profile is incomplete.
- Added support for showing the onboarding tour only once, based on the `showTooltip` flag in the login API response.
- Added a dynamic check to determine whether the student is enrolled in any course with mentorship enabled:
  - If no enrolled course has mentorship enabled, the onboarding tour dynamically filters out mentorship steps and only shows the relevant steps (e.g., Profile and Courses).
