### PR TITLE
fix: restrict live session access by batch

### DIFF
--- a/src/app/student/_components/chapter-content/LiveClassContent.tsx
+++ b/src/app/student/_components/chapter-content/LiveClassContent.tsx
@@ -3,11 +3,11 @@ import { useParams } from 'next/navigation'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
-import { Play, Check, VideoIcon } from 'lucide-react'
+import { Check, VideoIcon, Lock } from 'lucide-react'
 import useChapterCompletion from '@/hooks/useChapterCompletion'
+import useCourseSyllabus from '@/hooks/useCourseSyllabus'
 import { getEmbedLink } from '@/utils/students'
 import {
-    Session,
     LiveClassContentProps,
 } from '@/app/student/_components/chapter-content/componentChapterType'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -22,6 +22,10 @@ const LiveClassContent: React.FC<LiveClassContentProps> = ({
 }) => {
     const { courseId, moduleId } = useParams()
     const { progress, setProgress } = useVideoStore()
+
+    // Get student's own batch ID to check against the session's batch
+    const { syllabusData } = useCourseSyllabus(courseId as string)
+    const studentBatchId = syllabusData?.studentBatchId ?? null
 
     const playerRef = useRef<ReactPlayer>(null)
     const containerRef = useRef<HTMLDivElement>(null)
@@ -239,7 +243,15 @@ if (loading) {
         hangoutLink: session.hangoutLink,
         s3link: session.s3link,
         attendance: session.attendance,
+        batchId: session.batchId,
     }
+
+    // Batch restriction: if we know the session's batch and the student's batch,
+    // and they don't match → student is not allowed to join this session
+    const isWrongBatch =
+        typeof studentBatchId === 'number' &&
+        typeof item.batchId === 'number' &&
+        item.batchId !== studentBatchId
 
     if (item.type === 'live-class') {
         const isScheduled = item.status === 'upcoming'
@@ -328,19 +340,33 @@ if (loading) {
                         </div>
                     </div>
                     <div className="text-left">
-                        <Button
-                            className="mb-6 text-left font-semibold bg-primary hover:bg-primary-dark text-white"
-                            onClick={() =>
-                                item.hangoutLink &&
-                                window.open(item.hangoutLink, '_blank')
-                            }
-                            disabled={
-                                !item.hangoutLink ||
-                                item.hangoutLink === 'not found'
-                            }
-                        >
-                            Join Class
-                        </Button>
+                        {isWrongBatch ? (
+                            <div className="flex items-center gap-3 p-4 rounded-lg bg-destructive/10 border border-destructive/30 mb-6">
+                                <Lock className="w-5 h-5 text-destructive flex-shrink-0" />
+                                <div>
+                                    <p className="text-sm font-semibold text-destructive">
+                                        Session not available for your batch
+                                    </p>
+                                    <p className="text-xs text-muted-foreground mt-0.5">
+                                        This live session was scheduled for a different batch. Please check your batch schedule.
+                                    </p>
+                                </div>
+                            </div>
+                        ) : (
+                            <Button
+                                className="mb-6 text-left font-semibold bg-primary hover:bg-primary-dark text-white"
+                                onClick={() =>
+                                    item.hangoutLink &&
+                                    window.open(item.hangoutLink, '_blank')
+                                }
+                                disabled={
+                                    !item.hangoutLink ||
+                                    item.hangoutLink === 'not found'
+                                }
+                            >
+                                Join Class
+                            </Button>
+                        )}
                     </div>
                 </div>
             )

--- a/src/app/student/_components/chapter-content/componentChapterType.ts
+++ b/src/app/student/_components/chapter-content/componentChapterType.ts
@@ -154,6 +154,7 @@ export interface Session {
   status: string;
   attendance: string;
   duration: number;
+  batchId?: number;
 }
 
 export interface LiveClassContentProps {

--- a/src/hooks/hookType.ts
+++ b/src/hooks/hookType.ts
@@ -244,6 +244,20 @@ export interface UseChapterCompletionReturn {
 
 
 // UseChapterDetails
+export interface LiveClassSession {
+  id: number;
+  meetingId: string;
+  hangoutLink: string;
+  startTime: string;
+  endTime: string;
+  title: string;
+  s3link: string;
+  status: string;          // 'upcoming' | 'ongoing' | 'completed'
+  attendance: string;      // 'present' | 'absent'
+  duration: number;
+  batchId?: number;        // which batch this session belongs to
+}
+
 export interface ChapterDetails {
   id: number;
   title: string;
@@ -262,6 +276,7 @@ export interface ChapterDetails {
   version: string | null;
   chapterTrackingDetails: any[];
   status: string;
+  sessions?: LiveClassSession[];  // present when topicId === 8 (live class)
 }
 
 export interface UseChapterDetailsResponse {


### PR DESCRIPTION
Live Session Access Restriction:

- Fixed the issue where students from other batches could join live sessions.
- Added batch validation by comparing the live session batch ID with the student's batch ID.
- Students can now join a live session only if both batch IDs match.
- If the batch IDs do not match, the Join action is disabled, and the following message is displayed:
    "This live session was scheduled for a different batch. Please check your batch schedule."