### PR TITLE
Fix/rbac own role restrictions

### DIFF
--- a/src/app/[admin]/organizations/[organizationId]/settings/_components/ChangeUserRole.tsx
+++ b/src/app/[admin]/organizations/[organizationId]/settings/_components/ChangeUserRole.tsx
@@ -12,6 +12,12 @@ import {
 import { toast } from '@/components/ui/use-toast';
 import { getUser } from '@/store/store'
 import { useParams } from 'next/navigation'
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 // Role Cell Component
 
@@ -67,31 +73,46 @@ export const ChangeUserRole = ({ role, roles, rolesLoading, userId, userEmail, o
     }
 
     return (
-        <Select 
-            value={role} 
-            onValueChange={handleRoleChange} 
-            disabled={loading || isCurrentUser}
-        >
-            <SelectTrigger className="w-auto min-w-28 bg-white border-gray-200 h-8 text-sm capitalize">
-                <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-                {rolesLoading ? (
-                    <SelectItem value="loading" disabled>
-                        Loading...
-                    </SelectItem>
-                ) : (
-                    roles.map((roleOption: any) => (
-                        <SelectItem
-                            key={roleOption.id}
-                            value={roleOption.name}
-                            className="capitalize"
+        <TooltipProvider delayDuration={150}>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <span className="inline-block">
+                        <Select
+                            value={role}
+                            onValueChange={handleRoleChange}
+                            disabled={loading || isCurrentUser}
                         >
-                            {roleOption.name}
-                        </SelectItem>
-                    ))
+                            <SelectTrigger className="w-auto min-w-28 bg-white border-gray-200 h-8 text-sm capitalize">
+                                <SelectValue />
+                            </SelectTrigger>
+
+                            <SelectContent>
+                                {rolesLoading ? (
+                                    <SelectItem value="loading" disabled>
+                                        Loading...
+                                    </SelectItem>
+                                ) : (
+                                    roles.map((roleOption: any) => (
+                                        <SelectItem
+                                            key={roleOption.id}
+                                            value={roleOption.name}
+                                            className="capitalize"
+                                        >
+                                            {roleOption.name}
+                                        </SelectItem>
+                                    ))
+                                )}
+                            </SelectContent>
+                        </Select>
+                    </span>
+                </TooltipTrigger>
+
+                {isCurrentUser && (
+                    <TooltipContent side="top">
+                        <p>You can&apos;t change your own role.</p>
+                    </TooltipContent>
                 )}
-            </SelectContent>
-        </Select>
+            </Tooltip>
+        </TooltipProvider>
     )
 }

--- a/src/app/[admin]/organizations/[organizationId]/settings/_components/ChangeUserRole.tsx
+++ b/src/app/[admin]/organizations/[organizationId]/settings/_components/ChangeUserRole.tsx
@@ -21,14 +21,16 @@ type roleCellProps = {
   rolesLoading: boolean;
   onRoleUpdate?: () => void;
   roleId?: number;
+  userEmail: string;
 };
 
-export const ChangeUserRole = ({ role, roles, rolesLoading, userId, onRoleUpdate }: roleCellProps & { userId: number }) => {
+export const ChangeUserRole = ({ role, roles, rolesLoading, userId, userEmail, onRoleUpdate }: roleCellProps & { userId: number }) => {
     const { organizationId } = useParams()
     const { user } = getUser()
     const orgId = Number(organizationId) || user?.orgId;
     const { assignUserRole, loading } = useAssignUserRole()
     const [originalRole, setOriginalRole] = useState(role)
+    const isCurrentUser = user?.email?.trim().toLowerCase() === userEmail?.trim().toLowerCase()
 
     const handleRoleChange = async (newRoleName: string) => {
         // Only save if the role actually changed
@@ -68,7 +70,7 @@ export const ChangeUserRole = ({ role, roles, rolesLoading, userId, onRoleUpdate
         <Select 
             value={role} 
             onValueChange={handleRoleChange} 
-            disabled={loading}
+            disabled={loading || isCurrentUser}
         >
             <SelectTrigger className="w-auto min-w-28 bg-white border-gray-200 h-8 text-sm capitalize">
                 <SelectValue />

--- a/src/app/[admin]/organizations/[organizationId]/settings/_components/PermissionButtons.tsx
+++ b/src/app/[admin]/organizations/[organizationId]/settings/_components/PermissionButtons.tsx
@@ -12,11 +12,12 @@ interface PermissionButtonsProps {
     maxAllowedTier?: PermissionTier
     currentTier: number
     isAdminRole?: boolean
+    isOwnRole?: boolean
     hoveredRowId?: number | null
     onChange: (resourceId: number, tier: PermissionTier, isParent?: boolean) => void
 }
 
-const PermissionButtons: React.FC<PermissionButtonsProps> = ({ resourceId, isChild = false, moduleChildren, maxAllowedTier, currentTier, isAdminRole = false, hoveredRowId, onChange }) => {
+const PermissionButtons: React.FC<PermissionButtonsProps> = ({ resourceId, isChild = false, moduleChildren, maxAllowedTier, currentTier, isAdminRole = false, isOwnRole = false, hoveredRowId, onChange }) => {
     return (
         <div className="flex gap-8 flex-shrink-0" style={{ width: '620px' }}>
             {Object.values(PERMISSION_TIERS)
@@ -30,19 +31,19 @@ const PermissionButtons: React.FC<PermissionButtonsProps> = ({ resourceId, isChi
                         <button
                             key={tier.tier}
                             onClick={() => {
-                                if (!isAdminRole) {
+                                if (!isAdminRole && !isOwnRole) {
                                     if (!isDisabledByParent) {
                                         onChange(resourceId, tier.tier as PermissionTier, !isChild)
                                     }
                                 }
                             }}
-                            disabled={isAdminRole || isDisabledByParent}
+                            disabled={isAdminRole || isDisabledByParent || isOwnRole}
                             className={cn(
                                 'transition-all duration-200 rounded-md',
                                 'h-10 flex items-center justify-center flex-1',
                                 'text-xs font-semibold uppercase',
                                 'min-w-0 relative group',
-                                (isAdminRole || isDisabledByParent) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
+                                (isAdminRole || isDisabledByParent || isOwnRole) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
                                 isActive
                                     ? cn('border-2', tier.borderColorClass, tier.backgroundColor, tier.textColorClass)
                                     : cn(isChild ? 'bg-white hover:bg-gray-100' : 'bg-muted-light hover:bg-gray-200', tier.textColorClass)

--- a/src/app/[admin]/organizations/[organizationId]/settings/_components/RoleManagementPanel.tsx
+++ b/src/app/[admin]/organizations/[organizationId]/settings/_components/RoleManagementPanel.tsx
@@ -11,6 +11,7 @@ import UnsavedChangesDialog from './UnsavedChangesDialog'
 import { cn } from '@/lib/utils'
 import { permissionLevelToTier } from '@/utils/types/rbac'
 import { Button } from '@/components/ui/button'
+import { getUser } from '@/store/store'
 
 interface RoleManagementPanelProps {
     selectedRole: string | undefined
@@ -65,6 +66,9 @@ const RoleManagementPanel: React.FC<RoleManagementPanelProps> = ({ selectedRole,
         discardChanges,
     } = hook as any
 
+    const { user } = getUser()
+    const currentUserRole = user?.rolesList?.[0]?.toLowerCase()
+    const isOwnRole = selectedRole?.toLowerCase() === currentUserRole
     const isAdminRole = selectedRole?.toLowerCase() === 'admin'
 
     const toggleModuleExpansion = (moduleId: string) => {
@@ -214,6 +218,17 @@ const RoleManagementPanel: React.FC<RoleManagementPanelProps> = ({ selectedRole,
                 </div>
 
                 <div className="lg:col-span-3 space-y-6">
+                    {(isOwnRole || isAdminRole) && (
+                        <div className="flex items-center gap-3 px-2 py-1 text-sm text-secondary-dark">
+                            <AlertTriangle className="h-5 w-5 flex-shrink-0" />
+                            <p>
+                            {isOwnRole
+                                ? "You can't modify your own role's permissions. Switch to another role with sufficient privileges to make changes."
+                                : "You can't modify the Admin role's permissions. Switch to another role with sufficient privileges to make changes."}
+                            </p>
+                        </div>
+                    )}
+
                     <div className="relative">
                         <div className="bg-card rounded-lg border border-border overflow-hidden">
                             <div className="bg-background px-6 py-4 border-b border-border">
@@ -251,7 +266,7 @@ const RoleManagementPanel: React.FC<RoleManagementPanelProps> = ({ selectedRole,
                                                         </div>
                                                         <span className="text-base font-semibold text-foreground truncate">{moduleName}</span>
                                                     </div>
-                                                    <PermissionButtons resourceId={mod.children[0]?.id || 0} isChild={false} moduleChildren={mod.children} currentTier={permissionLevelToTier((permissionLevels as any)[mod.children[0]?.id] || 'No access')} onChange={handlePermissionChange} hoveredRowId={hoveredRowId} isAdminRole={isAdminRole} />
+                                                    <PermissionButtons resourceId={mod.children[0]?.id || 0} isChild={false} moduleChildren={mod.children} currentTier={permissionLevelToTier((permissionLevels as any)[mod.children[0]?.id] || 'No access')} onChange={handlePermissionChange} hoveredRowId={hoveredRowId} isAdminRole={isAdminRole} isOwnRole={isOwnRole} />
                                                 </div>
 
                                                 {(isExpanded) && (() => {
@@ -277,7 +292,7 @@ const RoleManagementPanel: React.FC<RoleManagementPanelProps> = ({ selectedRole,
                                                                 {showDisabledMessage ? (
                                                                     <div className="flex items-center justify-end text-sm text-muted-foreground italic" style={{ width: '620px' }}>Enable Parent Access to configure</div>
                                                                 ) : (
-                                                                    <PermissionButtons resourceId={child.id} isChild={true} currentTier={permissionLevelToTier((permissionLevels as any)[child.id] || 'No access')} maxAllowedTier={parentLevel as any} hoveredRowId={hoveredRowId} isAdminRole={isAdminRole} onChange={handlePermissionChange} />
+                                                                    <PermissionButtons resourceId={child.id} isChild={true} currentTier={permissionLevelToTier((permissionLevels as any)[child.id] || 'No access')} maxAllowedTier={parentLevel as any} hoveredRowId={hoveredRowId} isAdminRole={isAdminRole} isOwnRole={isOwnRole} onChange={handlePermissionChange} />
                                                                 )}
                                                             </div>
                                                         </div>
@@ -295,7 +310,7 @@ const RoleManagementPanel: React.FC<RoleManagementPanelProps> = ({ selectedRole,
                                         <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd"/></svg>
                                         <span>Permissions cascade down</span>
                                     </div>
-                                    <Button onClick={() => handleSaveAllPermissions(resolveRoleId)} disabled={!hasUnsavedChanges || assigning || isAdminRole} size="lg">
+                                    <Button onClick={() => handleSaveAllPermissions(resolveRoleId)} disabled={!hasUnsavedChanges || assigning || isAdminRole || isOwnRole} size="lg">
                                         <Save className="h-4 w-4 mr-2" />
                                         {assigning ? 'Saving...' : 'Save Configuration'}
                                     </Button>

--- a/src/app/[admin]/organizations/[organizationId]/settings/columns.tsx
+++ b/src/app/[admin]/organizations/[organizationId]/settings/columns.tsx
@@ -105,7 +105,8 @@ export const createColumns = (
             const role = row.getValue('roleName') as string
             const userId = row.original.userId
             const roleId = row.original.roleId
-            return <ChangeUserRole role={role} roles={roles} rolesLoading={rolesLoading} userId={userId} roleId={roleId} onRoleUpdate={refreshData} />
+            const userEmail = row.original.email
+            return <ChangeUserRole role={role} roles={roles} rolesLoading={rolesLoading} userId={userId} userEmail={userEmail} roleId={roleId} onRoleUpdate={refreshData} />
         },
     },
    {


### PR DESCRIPTION
Disabled role and permission editing for the logged-in user's own role.
Added helper messages and tooltip to explain why the actions are disabled.