### PR TITLE
fix: update student profile login flow and profile fixes

### DIFF
--- a/src/app/auth/login/_components/LoginPage.tsx
+++ b/src/app/auth/login/_components/LoginPage.tsx
@@ -82,30 +82,6 @@ function LoginPage() {
     const firstRowCards = socialProofData.slice(0, 5)
     const secondRowCards = socialProofData.slice(5, 8)
 
-    type LearnerProfileStrengthResponse = {
-        percentage?: number
-        profileCompletion?: number
-        isProfileComplete?: boolean
-        level?: string
-        message?: string
-    }
-
-    const getStudentStrengthPercentage = async (): Promise<number | null> => {
-        try {
-            const res = await api.get<LearnerProfileStrengthResponse>('/learner-profile/strength')
-            const completionValue =
-                typeof res.data?.profileCompletion === 'number'
-                    ? res.data.profileCompletion
-                    : typeof res.data?.percentage === 'number'
-                        ? res.data.percentage
-                        : null
-
-            return completionValue
-        } catch (error) {
-            console.error('Failed to fetch learner profile strength:', error)
-            return null
-        }
-    }
 
     const isMentorProfileComplete = (profile: MentorProfileResponse | null) => {
         if (!profile) return false
@@ -231,8 +207,10 @@ const handleGoogleSuccess = async (
                 
                 if (response.data.showTooltip) {
                     localStorage.setItem('isLoginFirst', 'true')
+                    localStorage.removeItem('skipProfileSetup')
                 } else {
                     localStorage.removeItem('isLoginFirst')
+                    localStorage.setItem('skipProfileSetup', 'true')
                 }
 
                 // Handle redirects based on user role
@@ -268,13 +246,11 @@ const handleGoogleSuccess = async (
                 } else if (redirectedUrl) {
                     router.push(redirectedUrl)
                 } else if (userRole === 'student') {
-                    const strengthPercentage = await getStudentStrengthPercentage()
-                    if (strengthPercentage !== null && strengthPercentage > 20) {
-                        router.push('/student')
-                    } else {
+                    if (response.data.showTooltip) {
                         router.push('/student/profile')
+                    } else {
+                        router.push('/student')
                     }
-                    
                 } else if (userRole === 'super_admin') {
                      router.push(`/${userRole}/organizations`)
                 } else {

--- a/src/app/student/_components/Header.tsx
+++ b/src/app/student/_components/Header.tsx
@@ -7,7 +7,6 @@ import { useRouter, usePathname, useSearchParams, useParams } from 'next/navigat
 import { Logout } from '@/utils/logout'
 import { useThemeStore, useLazyLoadedStudentData } from '@/store/store'
 import StudentProfileDropDown from './StudentProfileDropDown'
-import useLearnerProfileStrength from '@/hooks/useLearnerProfileStrength'
 import { useOnboardingStorage } from '@/hooks/use-profile'
 import { useLatestUpdatedCourse } from '@/hooks/useLatestUpdatedCourse'
 import { getMentorsHref } from '@/utils/studentMentorshipRoutes'
@@ -17,7 +16,6 @@ const Header = () => {
     const { studentData } = useLazyLoadedStudentData()
     const [showLogoutDialog, setShowLogoutDialog] = useState(false)
     const [isClient, setIsClient] = useState(false)
-    const { strengthPercentage, loading: isStrengthLoading } = useLearnerProfileStrength()
     const { onboardingData, isLoading: isOnboardingLoading } = useOnboardingStorage()
     const router = useRouter()
     const pathname = usePathname()
@@ -94,11 +92,8 @@ const Header = () => {
         !isOnboardingLoading &&
         !onboardingData?.isCompleted
 
-    const showProfileOption =
-        !isInProfileSetupFlow &&
-        !isStrengthLoading &&
-        strengthPercentage !== null &&
-        strengthPercentage >= 20
+    // Show profile option in dropdown whenever the student is not in the initial onboarding flow
+    const showProfileOption = !isInProfileSetupFlow
 
     // Check if we're on a course-related page
     const isOnCoursePage = pathname.includes('/course/')

--- a/src/app/student/_components/guided-tour/TourContext.tsx
+++ b/src/app/student/_components/guided-tour/TourContext.tsx
@@ -196,7 +196,9 @@ export const TourProvider: React.FC<{ children: React.ReactNode; mentorshipEnabl
       localStorage.setItem(TOUR_COMPLETED_KEY, 'true');
       setIsTourCompleted(true);
     }
-  }, []);
+    // After skipping, redirect to profile page so the student can fill in their details
+    router.push('/student/profile');
+  }, [router]);
 
   const finishTour = useCallback(async () => {
     setIsOpen(false);

--- a/src/app/student/_pages/EditProfilePage.tsx
+++ b/src/app/student/_pages/EditProfilePage.tsx
@@ -943,9 +943,6 @@ export const EditProfilePage: React.FC = () => {
       }
 
       const totalLocations = (remotePreference ? 1 : 0) + normalizedLocations.length;
-      if (totalLocations === 0) {
-        fieldErrors.push('Select at least 1 location');
-      }
       if (totalLocations > 6) {
         fieldErrors.push('Select maximum 5 cities + Remote');
       }
@@ -2101,7 +2098,13 @@ export const EditProfilePage: React.FC = () => {
                         </div>
                         <div>
                           <p className="text-xs text-muted-foreground font-medium mb-1">Year of study</p>
-                          <p className="font-medium">{step1?.yearOfStudy || '-'}</p>
+                          <p className="font-medium">
+                            {step1?.yearOfStudy
+                              ? step1.yearOfStudy === 'passed_out'
+                                ? 'Passout'
+                                : step1.yearOfStudy
+                              : '-'}
+                          </p>
                         </div>
                         <div>
                           <p className="text-xs text-muted-foreground font-medium mb-1">Expected graduation</p>
@@ -2383,29 +2386,36 @@ export const EditProfilePage: React.FC = () => {
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                               <div>
                                 <Label className="font-medium">Year of Study *</Label>
-                                <div className="grid grid-cols-4 gap-2 mt-2">
-                                  {['1st', '2nd', '3rd', '4th'].map((year) => (
-                                    <button
-                                      key={year}
-                                      type="button"
-                                      onClick={() =>
-                                        setEditedData((prev: any) => ({
-                                          ...prev,
-                                          step1: {
-                                            ...(prev.step1 || {}),
-                                            yearOfStudy: year,
-                                          },
-                                        }))
-                                      }
-                                      className={`py-2 px-3 rounded-lg border-2 font-medium text-sm transition-all ${
-                                        (editedData?.step1?.yearOfStudy ?? step1.yearOfStudy) === year
-                                          ? 'border-primary bg-primary text-primary-foreground'
-                                          : 'border-border bg-background hover:border-primary'
-                                      }`}
-                                    >
-                                      {year}
-                                    </button>
-                                  ))}
+                                <div className="mt-2">
+                                  <Select
+                                    value={editedData?.step1?.yearOfStudy ?? step1.yearOfStudy}
+                                    onValueChange={(value) =>
+                                      setEditedData((prev: any) => ({
+                                        ...prev,
+                                        step1: {
+                                          ...(prev.step1 || {}),
+                                          yearOfStudy: value,
+                                        },
+                                      }))
+                                    }
+                                  >
+                                    <SelectTrigger>
+                                      <SelectValue placeholder="Select year of study" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {[
+                                        { value: '1st', label: '1st' },
+                                        { value: '2nd', label: '2nd' },
+                                        { value: '3rd', label: '3rd' },
+                                        { value: '4th', label: '4th' },
+                                        { value: 'passed_out', label: 'Passout' },
+                                      ].map((item) => (
+                                        <SelectItem key={item.value} value={item.value}>
+                                          {item.label}
+                                        </SelectItem>
+                                      ))}
+                                    </SelectContent>
+                                  </Select>
                                 </div>
                               </div>
                               
@@ -3048,23 +3058,27 @@ export const EditProfilePage: React.FC = () => {
                   )}
 
                   {/* Preferred Locations */}
-                  {step4.locationPreferences && (
-                    <div className="mb-6 pb-6 border-b border-border/30">
-                      <Label className="text-xs font-medium text-muted-foreground mb-3 block">Preferred location</Label>
-                      <div className="flex flex-wrap gap-2">
-                        {step4.locationPreferences.remote && (
-                          <Badge variant="secondary" className="bg-green-100 text-green-700">
-                            Open to Remote
-                          </Badge>
-                        )}
-                        {step4.locationPreferences.cities?.map((city) => (
-                          <Badge key={city} variant="secondary" className="bg-black dark:bg-white text-white dark:text-black">
-                            {city}
-                          </Badge>
-                        ))}
-                      </div>
+                  <div className="mb-6 pb-6 border-b border-border/30">
+                    <Label className="text-xs font-medium text-muted-foreground mb-3 block">Preferred location</Label>
+                    <div className="flex flex-wrap gap-2">
+                      {!step4.locationPreferences?.remote && (!step4.locationPreferences?.cities || step4.locationPreferences.cities.length === 0) ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : (
+                        <>
+                          {step4.locationPreferences?.remote && (
+                            <Badge variant="secondary" className="bg-green-100 text-green-700">
+                              Open to Remote
+                            </Badge>
+                          )}
+                          {step4.locationPreferences?.cities?.map((city) => (
+                            <Badge key={city} variant="secondary" className="bg-black dark:bg-white text-white dark:text-black">
+                              {city}
+                            </Badge>
+                          ))}
+                        </>
+                      )}
                     </div>
-                  )}
+                  </div>
                   
                   {/* Salary Expectations */}
                   {step4.salaryExpectations && (step4.salaryExpectations.internship || step4.salaryExpectations.fullTime) && (

--- a/src/app/student/page.tsx
+++ b/src/app/student/page.tsx
@@ -3,50 +3,36 @@
 import { useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import StudentDashboard from './_pages/StudentDashboard';
-// import ZoeFlashScreen from '../_components/ZoeFlashScreen';
 import { useTour } from './_components/guided-tour';
 import { useOnboardingStorage } from '@/hooks/use-profile';
 
 const Page = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { startTour, isTourCompleted, isOpen } = useTour();
+  const { isTourCompleted, isOpen } = useTour();
   const { onboardingData, isLoading } = useOnboardingStorage();
   const stayOnDashboard = searchParams.get('stay') === 'dashboard';
 
-  // Route guard: Redirect to profile page if profile is incomplete
+  // Route guard: only redirect to profile if showTooltip was true (skipProfileSetup not set)
   useEffect(() => {
     if (isLoading) return;
-    if (isOpen || isTourCompleted) return; // Bypass if tour is active or was just completed/skipped
-    if (onboardingData && !onboardingData.isCompleted && !stayOnDashboard) {
+    if (isOpen || isTourCompleted) return;
+    if (stayOnDashboard) return;
+    // showTooltip was false on login — user should stay on dashboard regardless of profile completion
+    const skipProfileSetup = localStorage.getItem('skipProfileSetup');
+    if (skipProfileSetup) return;
+    if (onboardingData && !onboardingData.isCompleted) {
       router.push('/student/profile');
     }
   }, [onboardingData, isLoading, router, isOpen, isTourCompleted, stayOnDashboard]);
 
-  // Start guided tour if necessary and profile is completed
-  useEffect(() => {
-    if (isLoading) return;
-    if (onboardingData && !onboardingData.isCompleted) return;
-
-    if (isTourCompleted) return;
-    const isLoginFirst = localStorage.getItem('isLoginFirst');
-    if (!isLoginFirst) return;
-    localStorage.removeItem('isLoginFirst');
-    startTour(1);
-  }, [isTourCompleted, startTour, onboardingData, isLoading]);
-
-  // Return null during loading or redirecting to prevent UI flash (bypass during tour)
-  if (isLoading || (!isOpen && !isTourCompleted && onboardingData && !onboardingData.isCompleted && !stayOnDashboard)) {
+  // Prevent UI flash while redirecting
+  if (isLoading || (!isOpen && !isTourCompleted && onboardingData && !onboardingData.isCompleted && !stayOnDashboard && !localStorage.getItem('skipProfileSetup'))) {
     return null;
   }
 
   return (
     <div>
-      {/* <ZoeFlashScreen
-        isOpen={showAnnouncement}
-        onClose={handleCloseAnnouncement}
-        onStartInterview={handleStartInterview}
-      /> */}
       <StudentDashboard />
     </div>
   );

--- a/src/app/student/profile/ProfileStep1.tsx
+++ b/src/app/student/profile/ProfileStep1.tsx
@@ -69,8 +69,10 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
   const [selectedYear, setSelectedYear] = useState<string>(formData.graduationDate.year || '');
   const [customDegree, setCustomDegree] = useState<string>('');
   const [customBranch, setCustomBranch] = useState<string>('');
+  const [isOtherBranchSelected, setIsOtherBranchSelected] = useState<boolean>(false);
   const fullNameEditedRef = useRef(false);
   const resumeClearedRef = useRef(false);
+  const isAutofillRef = useRef(false);
   const { colleges: filteredColleges, isLoading: isLoadingColleges } = useCollegeSearch(collegeSearch);
 
   const buildEmptyStep1Data = (): Step1Type => ({
@@ -153,6 +155,11 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
     const unique = Array.from(new Set(source));
     return unique.includes('Other') ? unique : [...unique, 'Other'];
   }, [formData.degree, getBranchesForDegree, selectedDegreeDetails]);
+
+  // Keep a ref so effects can read the latest branches without adding it
+  // as a dependency (which would cause unintended autofill re-runs).
+  const branchesRef = useRef<string[]>(branches);
+  useEffect(() => { branchesRef.current = branches; }, [branches]);
   
   // Handle custom degree initialization
   useEffect(() => {
@@ -165,21 +172,50 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
     }
   }, [degreeDetails, formData.degree, degreeOptions, customDegree]);
 
-  // Handle custom branch initialization
-  useEffect(() => {
-    if (!formData.branch || formData.branch === 'Other') {
-      return;
-    }
+  // Helper: find the canonical branch name from the list using case-insensitive match
+  const findBranchInList = (value: string, list: string[]): string | undefined => {
+    if (!value) return undefined;
+    const lower = value.trim().toLowerCase();
+    return list.find((b) => b.toLowerCase() === lower);
+  };
 
-    const isCustomBranch = !branches.includes(formData.branch);
-    if (isCustomBranch && customBranch !== formData.branch) {
+  // When loading existing data, if the saved branch is not in the dropdown list
+  // (exact match) but IS there case-insensitively, normalise it to the API spelling.
+  // If it genuinely isn't in the list at all, treat it as a custom "Other" value.
+  // We never store 'Other' in formData.branch — the real typed value lives there.
+  useEffect(() => {
+    if (isAutofillRef.current) return;
+    if (!formData.branch || formData.branch === 'Other') return;
+    if (branches.length === 0) return;
+
+    // Exact match — already correct, nothing to do
+    if (branches.includes(formData.branch)) return;
+
+    const canonical = findBranchInList(formData.branch, branches);
+    if (canonical) {
+      // Same branch, different casing — update to the API's spelling so the
+      // Select value matches a real SelectItem and displays correctly.
+      isAutofillRef.current = true;
+      setFormData((prev) => ({ ...prev, branch: canonical }));
+      Promise.resolve().then(() => { isAutofillRef.current = false; });
+    } else if (customBranch !== formData.branch) {
+      // Genuinely not in the list — it's a custom typed value
       setCustomBranch(formData.branch);
+      setIsOtherBranchSelected(true);
     }
   }, [branches, formData.branch, customBranch]);
   
   // Auto-save form data on change
   useEffect(() => {
     if (isResumeCleared) {
+      return;
+    }
+
+    // Skip notifying the parent when the change was triggered by the parent's
+    // own initialData update (autofill). Notifying in that case creates a
+    // feedback loop: parent data → setFormData → onFieldChange → parent
+    // updates initialData again → setFormData again → infinite loop.
+    if (isAutofillRef.current) {
       return;
     }
 
@@ -216,16 +252,21 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
       resumeClearedRef.current = true;
       fullNameEditedRef.current = false;
       lastAutofillRef.current = '';
+      isAutofillRef.current = true;
       setFormData(buildEmptyStep1Data());
       setSelectedMonth('');
       setSelectedYear('');
       setCustomDegree('');
       setCustomBranch('');
+      setIsOtherBranchSelected(false);
       setCollegeSearch('');
       setShowCollegeDropdown(false);
       setShowGraduationDatePicker(false);
       setErrors({});
       setValidations({});
+      Promise.resolve().then(() => {
+        isAutofillRef.current = false;
+      });
       return;
     }
 
@@ -288,14 +329,42 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
       graduationDate: initialData.graduationDate,
     });
 
-    const nextFormData = buildStep1FromInitialData(initialData);
+    let nextFormData = buildStep1FromInitialData(initialData);
+
+    // Flag that the upcoming formData change is driven by initialData (autofill)
+    // so the auto-save effect won't echo it back to the parent and cause an
+    // infinite update loop.
+    isAutofillRef.current = true;
 
     fullNameEditedRef.current = false;
     setFormData(nextFormData);
     setSelectedMonth(nextFormData.graduationDate.month);
     setSelectedYear(nextFormData.graduationDate.year);
     setCustomDegree(nextFormData.degree && nextFormData.degree !== 'Other' ? nextFormData.degree : '');
-    setCustomBranch(nextFormData.branch && nextFormData.branch !== 'Other' ? nextFormData.branch : '');
+    // If the saved branch is a custom value (not in the dropdown list), pre-fill
+    // customBranch so the text input shows it. If it matches case-insensitively,
+    // use the API's canonical spelling so the Select displays it correctly.
+    if (nextFormData.branch && nextFormData.branch !== 'Other' && branchesRef.current.length > 0) {
+      const canonical = branchesRef.current.find(
+        (b) => b.toLowerCase() === nextFormData.branch.toLowerCase()
+      );
+      if (canonical && canonical !== nextFormData.branch) {
+        // Normalise to API spelling — update the branch to canonical casing
+        nextFormData = { ...nextFormData, branch: canonical };
+        setFormData(nextFormData);
+      } else if (!canonical) {
+        // Not in the list at all — it's a custom value
+        setCustomBranch(nextFormData.branch);
+        setIsOtherBranchSelected(true);
+      }
+    } else if (nextFormData.branch && nextFormData.branch !== 'Other' && branchesRef.current.length === 0) {
+      // Branches haven't loaded yet — the initialization effect will handle it
+      setCustomBranch('');
+      setIsOtherBranchSelected(false);
+    } else {
+      setCustomBranch('');
+      setIsOtherBranchSelected(false);
+    }
     setErrors({});
 
     if (nextFormData.phoneNumber) {
@@ -308,6 +377,14 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
     }
 
     lastAutofillRef.current = signature;
+
+    // Clear the autofill flag after React has flushed the state updates.
+    // Using a microtask (Promise.resolve) ensures this runs after all
+    // synchronous setState calls above have been scheduled, but before the
+    // next user interaction can trigger the auto-save effect.
+    Promise.resolve().then(() => {
+      isAutofillRef.current = false;
+    });
   }, [initialData]);
 
   // Close college dropdown when clicking outside
@@ -351,46 +428,46 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
   };
 
   // Validate form
-  const validateForm = (): Record<string, string> => {
+  const validateForm = (data: Step1Type = formData): Record<string, string> => {
     const newErrors: Record<string, string> = {};
 
-    if (!formData.fullName.trim()) {
+    if (!data.fullName.trim()) {
       newErrors.fullName = 'Full name is required';
     }
 
-    if (!formData.phoneNumber.trim()) {
+    if (!data.phoneNumber.trim()) {
       newErrors.phoneNumber = 'Phone number is required';
-    } else if (!validatePhoneNumber(formData.phoneNumber)) {
+    } else if (!validatePhoneNumber(data.phoneNumber)) {
       newErrors.phoneNumber = 'Enter a valid 10-digit Indian mobile number';
     }
 
-    if (!(formData.linkedin ?? '').trim()) {
+    if (!(data.linkedin ?? '').trim()) {
       newErrors.linkedin = 'LinkedIn Profile is required';
     } else {
       // LinkedIn URL validation
       const linkedinRegex = /^https?:\/\/(www\.)?linkedin\.com\/in\/[A-Za-z0-9_-]+\/?$/;
-      if (!linkedinRegex.test((formData.linkedin || '').trim())) {
+      if (!linkedinRegex.test((data.linkedin || '').trim())) {
         newErrors.linkedin = 'Enter a valid LinkedIn profile URL';
       }
     }
 
-    if (!formData.collegeName && !formData.customCollege) {
+    if (!data.collegeName && !data.customCollege) {
       newErrors.college = 'College selection is required';
     }
 
-    if (!(formData.degree ?? '').trim()) {
+    if (!(data.degree ?? '').trim()) {
       newErrors.degree = 'Degree selection is required';
     }
 
-    if (!formData.branch) {
+    if (!data.branch || data.branch === 'Other') {
       newErrors.branch = 'Branch selection is required';
     }
 
-    if (!formData.graduationDate.month && !formData.graduationDate.year) {
+    if (!data.graduationDate.month && !data.graduationDate.year) {
       newErrors.graduationDate = 'Graduation month and year are required';
-    } else if (!formData.graduationDate.month) {
+    } else if (!data.graduationDate.month) {
       newErrors.graduationDate = 'Graduation month is required';
-    } else if (!formData.graduationDate.year) {
+    } else if (!data.graduationDate.year) {
       newErrors.graduationDate = 'Graduation year is required';
     }
 
@@ -500,6 +577,7 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
         setCustomDegree('');
       }
       setCustomBranch('');
+      setIsOtherBranchSelected(false);
       if (errors.degree || errors.branch) {
         setErrors((prev) => {
           const next = { ...prev };
@@ -519,14 +597,17 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
       }
 
       if (value === 'Other') {
-        // When "Other" is selected for branch, keep the dropdown value as "Other"
+        // When "Other" is selected, clear formData.branch so it's empty
+        // until the user types something in the custom input.
+        setIsOtherBranchSelected(true);
         setFormData((prev) => ({
           ...prev,
-          branch: 'Other',
+          branch: '',
         }));
-        // Don't clear customBranch here - let user continue typing
+        // Keep customBranch as-is so they don't lose what they already typed
       } else {
-        // When a predefined branch is selected
+        // When a predefined branch is selected, store it as the real value
+        setIsOtherBranchSelected(false);
         setFormData((prev) => ({
           ...prev,
           branch: value,
@@ -577,10 +658,11 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
 
   const handleCustomBranchChange = (value: string) => {
     setCustomBranch(value);
-    // Always update form data when typing in custom field
+    setIsOtherBranchSelected(true);
+    // Store the real typed value in formData.branch directly.
     setFormData((prev) => ({
       ...prev,
-      branch: value.trim() || 'Other', // Use the custom value or fallback to "Other"
+      branch: value,
     }));
   };
 
@@ -627,7 +709,10 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const validationErrors = validateForm();
+
+    // formData.branch always holds the real value (never 'Other').
+    // Just validate and submit directly.
+    const validationErrors = validateForm(formData);
     if (Object.keys(validationErrors).length === 0) {
       onNext(formData);
       return;
@@ -651,10 +736,16 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
   const hasManualCollege = Boolean(formData.customCollege?.trim());
   const isSearchCollegeDisabled = hasManualCollege;
   const isManualCollegeDisabled = hasSelectedCollege;
+  // Show the custom text input when:
+  // 1. User explicitly picked "Other" from the dropdown, OR
+  // 2. The current branch value is a custom typed value (not in the known list)
   const shouldShowCustomBranchInput =
-    formData.branch === 'Other' ||
-    Boolean(customBranch.trim()) ||
-    Boolean(formData.branch && !branches.includes(formData.branch));
+    isOtherBranchSelected ||
+    Boolean(
+      formData.branch &&
+      branches.length > 0 &&
+      !branches.includes(formData.branch)
+    );
 
   return (
     <>
@@ -973,28 +1064,34 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
                       <SelectValue placeholder="Select Degree" />
                     </SelectTrigger>
                     <SelectContent>
-                      {formData.degree &&
-                        formData.degree !== 'Other' &&
-                        !isDegreeLoading &&
-                        !degreeOptions.includes(formData.degree) && (
-                          <SelectItem value={formData.degree}>{formData.degree}</SelectItem>
-                        )}
                       {isDegreeLoading ? (
-                        <SelectItem value="loading" disabled>
-                          Loading degrees...
-                        </SelectItem>
-                      ) : degreeOptions.length > 0 ? (
-                        degreeOptions.map((degree) => (
-                          <SelectItem key={degree} value={degree}>
-                            {degree}
+                        <>
+                          {/* While loading, keep the current selection visible */}
+                          {formData.degree && formData.degree !== 'Other' && (
+                            <SelectItem value={formData.degree}>{formData.degree}</SelectItem>
+                          )}
+                          <SelectItem value="loading" disabled>
+                            Loading degrees...
                           </SelectItem>
-                        ))
+                        </>
+                      ) : degreeOptions.length > 0 ? (
+                        <>
+                          {formData.degree &&
+                            formData.degree !== 'Other' &&
+                            !degreeOptions.includes(formData.degree) && (
+                              <SelectItem value={formData.degree}>{formData.degree}</SelectItem>
+                            )}
+                          {degreeOptions.map((degree) => (
+                            <SelectItem key={degree} value={degree}>
+                              {degree}
+                            </SelectItem>
+                          ))}
+                        </>
                       ) : (
                         <SelectItem value="no-degrees" disabled>
                           No degrees available
                         </SelectItem>
                       )}
-                      {/* <SelectItem value="Other">Other</SelectItem> */}
                     </SelectContent>
                   </Select>
                   {errors.degree && (
@@ -1029,15 +1126,16 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
                           <Select 
                             value={(() => {
                               const branch = formData.branch ?? '';
-                              // If it's empty, return empty
+                              // User explicitly picked "Other" but hasn't typed yet
+                              if (isOtherBranchSelected && !branch) return 'Other';
+                              // Nothing selected yet — show placeholder
                               if (!branch) return '';
-                              if (branch === 'Other') return 'Other';
-                              // Preserve previously selected branch while options are still loading
+                              // Branches still loading — show what we have
                               if (branches.length === 0) return branch;
-                              // If it's a predefined branch (either API or mock data), show it
+                              // It's a known branch — show it directly
                               if (branches.includes(branch)) return branch;
-                              // Keep the saved branch visible even if the refreshed branch list does not include it
-                              return branch;
+                              // It's a custom typed value — show "Other" in the dropdown
+                              return 'Other';
                             })()} 
                             onValueChange={(value) => handleSelectChange('branch', value)}
                             disabled={!hasSelectedDegree}
@@ -1047,9 +1145,17 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
                             </SelectTrigger>
                             <SelectContent>
                               {isBranchLoading ? (
-                                <SelectItem value="loading" disabled>
-                                  Loading branches...
-                                </SelectItem>
+                                <>
+                                  {/* While loading, keep the current selection visible */}
+                                  {formData.branch && formData.branch !== 'Other' && (
+                                    <SelectItem value={formData.branch}>
+                                      {formData.branch}
+                                    </SelectItem>
+                                  )}
+                                  <SelectItem value="loading" disabled>
+                                    Loading branches...
+                                  </SelectItem>
+                                </>
                               ) : branches.length > 0 ? (
                                 <>
                                   {formData.branch && formData.branch !== 'Other' && !branches.includes(formData.branch) && (
@@ -1086,12 +1192,12 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
                     </Tooltip>
                   </TooltipProvider>
                   
-                  {/* Custom Branch Input - Show when "Other" is selected or custom branch */}
+                  {/* Custom Branch Input - only shown when user selects "Other" */}
                   {shouldShowCustomBranchInput && (
                     <div className="mt-2">
                       <Input
                         placeholder="Enter your branch name"
-                        value={customBranch || (formData.branch && formData.branch !== 'Other' ? formData.branch : '')}
+                        value={customBranch}
                         onChange={(e) => handleCustomBranchChange(e.target.value)}
                         className="w-full"
                       />
@@ -1114,22 +1220,29 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
                   <Label className="font-medium text-left block">
                     Year of Study <span className="text-destructive">*</span>
                   </Label>
-                  <div className="grid grid-cols-4 gap-2">
-                    {['1st', '2nd', '3rd', '4th'].map((year) => (
-                      <button
-                        key={year}
-                        type="button"
-                        onClick={() => setFormData((prev) => ({ ...prev, yearOfStudy: year as any }))}
-                        className={`py-2 px-3 rounded-lg border-2 font-medium text-sm transition-all ${
-                          formData.yearOfStudy === year
-                            ? 'border-primary bg-primary text-primary-foreground'
-                            : 'border-border bg-background hover:border-primary'
-                        }`}
-                      >
-                        {year}
-                      </button>
-                    ))}
-                  </div>
+                  <Select
+                    value={formData.yearOfStudy}
+                    onValueChange={(value) =>
+                      setFormData((prev) => ({ ...prev, yearOfStudy: value as any }))
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select year of study" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {[
+                        { value: '1st', label: '1st' },
+                        { value: '2nd', label: '2nd' },
+                        { value: '3rd', label: '3rd' },
+                        { value: '4th', label: '4th' },
+                        { value: 'passed_out', label: 'Passout' },
+                      ].map((item) => (
+                        <SelectItem key={item.value} value={item.value}>
+                          {item.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
 
                 {/* Graduation Date */}

--- a/src/app/student/profile/ProfileStep4.tsx
+++ b/src/app/student/profile/ProfileStep4.tsx
@@ -134,9 +134,6 @@ export const ProfileStep4Component: React.FC<ProfileStep4Props> = ({
       newErrors.roles = 'Select maximum 5 roles';
     }
 
-    if (totalLocations === 0) {
-      newErrors.locations = 'Select at least 1 location';
-    }
     if (totalLocations > 6) {
       newErrors.locations = 'Select maximum 5 cities + Remote';
     }

--- a/src/app/student/profile/page.tsx
+++ b/src/app/student/profile/page.tsx
@@ -18,34 +18,31 @@ export default function Page() {
     setIsClient(true);
   }, []);
 
-  // Route guard: Redirect to dashboard if profile is complete (and not in force edit mode)
+  // Route guard: redirect to dashboard only if profile is complete and not in edit mode
   useEffect(() => {
     if (!isClient || isLoading) return;
-    if (isOpen) return; // Bypass route guard if guided tour is active
+    if (isOpen) return; // don't redirect while tour is active
     if (onboardingData?.isCompleted && !forceEditMode) {
       router.push('/student');
     }
   }, [isClient, isLoading, onboardingData, forceEditMode, router, isOpen]);
 
-  // Start guided tour if necessary and profile is incomplete
+  // Start tour if isLoginFirst is set (showTooltip was true from login api)
   useEffect(() => {
     if (!isClient || isLoading) return;
-    if (onboardingData?.isCompleted && !forceEditMode) return;
-
-    if (!isTourCompleted) {
-      const isLoginFirst = localStorage.getItem('isLoginFirst');
-      if (isLoginFirst) {
-        localStorage.removeItem('isLoginFirst');
-        startTour();
-      }
+    if (isTourCompleted) return;
+    const isLoginFirst = localStorage.getItem('isLoginFirst');
+    if (isLoginFirst) {
+      localStorage.removeItem('isLoginFirst');
+      startTour();
     }
-  }, [isClient, isLoading, isTourCompleted, startTour, onboardingData, forceEditMode]);
+  }, [isClient, isLoading, isTourCompleted, startTour]);
 
   if (isLoading) {
     return null;
   }
 
-  // Prevent flashing profile page while redirecting complete profile to dashboard (bypass during tour)
+  // Prevent flashing while redirecting (bypass during active tour)
   if (!isOpen && onboardingData?.isCompleted && !forceEditMode) {
     return null;
   }

--- a/src/lib/profile.types.ts
+++ b/src/lib/profile.types.ts
@@ -8,7 +8,7 @@ export interface OnboardingStep1 {
   customCollege?: string;
   degree?: string;
   branch: string;
-  yearOfStudy: '1st' | '2nd' | '3rd' | '4th';
+  yearOfStudy: '1st' | '2nd' | '3rd' | '4th' | 'passed_out';
   graduationDate: {
     month: string;
     year: string;


### PR DESCRIPTION
Student Profile Fixes

- Updated the student login flow:
   On first-time login, the login API response is checked using the showTooltip flag.
   If showTooltip is true, the student is redirected to /student/profile.
   If showTooltip is false, the student is redirected to /student.
 
- Updated the tour flow so that after skipping or completing the tour, the user is redirected to /student/profile.

- Added a Passout option to the Year of Study dropdown in the profile steps.

- Fixed the branch field validation issue that occurred while adding or editing the branch name.

- Updated the Preferred Location field to make it optional instead of requiring at least one location