### PR TITLE
fix: integrate new attendance endpoints and download flow

### DIFF
--- a/src/app/[admin]/hooks/useAttendanceStatus.ts
+++ b/src/app/[admin]/hooks/useAttendanceStatus.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { api } from '@/utils/axios.config'
+
+export interface AttendanceRecord {
+    id?: number
+    userId: number | string
+    batchId?: number
+    bootcampId?: number
+    sessionId?: number | string
+    attendanceDate?: string
+    name?: string
+    email?: string
+    status?: string
+    duration?: number
+    version?: string | null
+    createdAt?: string
+}
+
+export interface AttendanceStatusData {
+    sessionId: number | string
+    sessionStatus: string
+    isZoomMeet: boolean
+    ready: boolean
+    state: string
+    reason: string | null
+    totalStudents: number
+    presentCount: number
+    absentCount: number
+    attendancePercentage: number
+    studentAttendanceRecords: AttendanceRecord[]
+}
+
+export interface AttendanceStatusResponse {
+    success: boolean
+    data: AttendanceStatusData
+    message: string
+}
+
+export interface UseAttendanceStatusOptions {
+    enabled?: boolean
+}
+
+export function useAttendanceStatus(
+    sessionId: string | number | null | undefined,
+    options: UseAttendanceStatusOptions = {}
+) {
+    const { enabled = true } = options
+
+    const [attendanceStatus, setAttendanceStatus] = useState<AttendanceStatusData | null>(null)
+    const [loading, setLoading] = useState<boolean>(false)
+    const [error, setError] = useState<Error | null>(null)
+    const mountedRef = useRef(true)
+
+    useEffect(() => {
+        mountedRef.current = true
+        return () => {
+            mountedRef.current = false
+        }
+    }, [])
+
+    const fetchAttendanceStatus = useCallback(
+        async (fetchSessionId?: string | number) => {
+            const id = fetchSessionId ?? sessionId
+            if (!id) return null
+
+            setLoading(true)
+            setError(null)
+
+            try {
+                const response = await api.get<AttendanceStatusResponse>(
+                    `/classes/attendance/${id}`
+                )
+                const data = response.data?.data ?? null
+
+                if (mountedRef.current) {
+                    setAttendanceStatus(data)
+                }
+
+                return data
+            } catch (err: any) {
+                if (mountedRef.current) {
+                    setError(err)
+                    console.error('Error fetching attendance status:', err)
+                }
+                throw err
+            } finally {
+                if (mountedRef.current) {
+                    setLoading(false)
+                }
+            }
+        },
+        [sessionId]
+    )
+
+    useEffect(() => {
+        if (enabled && sessionId) {
+            fetchAttendanceStatus()
+        }
+    }, [sessionId, enabled, fetchAttendanceStatus])
+
+    /**
+     * `ready` is true when the API returns ready: true.
+     * The `state` field can be "ready" or "completed" depending on processing stage.
+     */
+    const isAttendanceReady = attendanceStatus?.ready === true
+
+    return {
+        attendanceStatus,
+        isAttendanceReady,
+        loading,
+        error,
+        fetchAttendanceStatus,
+    }
+}
+
+export default useAttendanceStatus

--- a/src/app/[admin]/organizations/[organizationId]/courses/[courseId]/module/_components/liveClass/LiveClass.tsx
+++ b/src/app/[admin]/organizations/[organizationId]/courses/[courseId]/module/_components/liveClass/LiveClass.tsx
@@ -27,6 +27,7 @@ import * as z from 'zod'
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
 import { getModuleData, getChapterDataState } from '@/store/store'
 import { useUpdateLiveClassSession} from '@/app/[admin]/hooks/useUpdateLiveClassSession'
+import { useAttendanceStatus } from '@/app/[admin]/hooks/useAttendanceStatus'
 
 const liveClassSchema = z
     .object({
@@ -75,6 +76,10 @@ const LiveClass = ({
     const [batchData, setBatchData] = useState<any[]>([])
     const [recordingLink, setRecordingLink] = useState<string | null>(null)
     const { getClassAnalytics } = useClassAnalytics()
+    const { attendanceStatus, isAttendanceReady, loading: attendanceLoading } = useAttendanceStatus(
+        session?.id,
+        { enabled: session?.status?.toLowerCase() === 'completed' }
+    )
         const { moduleData, setModuleData } = getModuleData()    
         const { chapterData, setChapterData } = getChapterDataState()    
         const isUpcoming = session?.status?.toLowerCase() === 'upcoming'
@@ -127,76 +132,39 @@ const LiveClass = ({
         }
     }
 
-    const handleDownloadAttendance = async () => {
-        if (!canEdit) return
-        try {
-            const sessionId = session.id || session.meetingId || session.title
-            const data = await getClassAnalytics({ classId: sessionId })
+    const handleDownloadAttendance = () => {
+        if (!canEdit || !attendanceStatus) return
 
-            const studentRecords =
-                data?.data?.session?.studentAttendanceRecords ?? []
-            const invited = data?.data?.session?.invitedStudents ?? []
+        const records = attendanceStatus.studentAttendanceRecords ?? []
 
-            type AttendanceRecord = {
-                userId: number | string
-                duration?: number
-                status?: string
-            }
-
-            const attendanceMap = new Map(
-                studentRecords.map((r: AttendanceRecord) => [r.userId, r])
-            )
-
-            const attendanceData = invited.map((student: any) => {
-                const record = attendanceMap.get(student.userId) as
-                    | AttendanceRecord
-                    | undefined
-                return {
-                    userId: student.userId,
-                    name: student.name ?? '',
-                    email: student.email ?? '',
-                    duration:
-                        record && record.duration !== undefined
-                            ? record.duration
-                            : 0,
-                    attendance:
-                        record && record.status ? record.status : 'absent',
-                }
-            })
-
-            if (attendanceData.length === 0) {
-                toast.error({ title: 'No attendance data to download.' })
-                return
-            }
-
-
-            const headers = Object.keys(attendanceData[0])
-            const csvContent = `${headers.join(',')}\n${attendanceData
-                .map((row: any) =>
-                    headers
-                        .map((header) => `"${String(row[header] ?? '')}"`)
-                        .join(',')
-                )
-                .join('\n')}`
-
-            const encodedUri =
-                'data:text/csv;charset=utf-8,' + encodeURI(csvContent)
-            const link = document.createElement('a')
-            link.setAttribute(
-                'href',
-                encodedUri
-            )
-            link.setAttribute(
-                'download',
-                `${data?.data?.session?.title ?? 'attendance'}_attendance.csv`
-            )
-            document.body.appendChild(link)
-            link.click()
-            document.body.removeChild(link)
-        } catch (err) {
-            console.error('Failed to download attendance', err)
-            toast.error({ title: 'Failed to download attendance' })
+        if (records.length === 0) {
+            toast.error({ title: 'No attendance data to download.' })
+            return
         }
+
+        const csvRows = records.map((r: any) => ({
+            userId: r.userId,
+            name: r.name ?? '',
+            email: r.email ?? '',
+            status: r.status ?? 'absent',
+            duration: r.duration ?? 0,
+            attendanceDate: r.attendanceDate ?? '',
+        }))
+
+        const headers = Object.keys(csvRows[0])
+        const csvContent = `${headers.join(',')}\n${csvRows
+            .map((row: any) =>
+                headers.map((h) => `"${String(row[h] ?? '')}"`).join(',')
+            )
+            .join('\n')}`
+
+        const encodedUri = 'data:text/csv;charset=utf-8,' + encodeURI(csvContent)
+        const link = document.createElement('a')
+        link.setAttribute('href', encodedUri)
+        link.setAttribute('download', `${content?.title ?? 'attendance'}_attendance.csv`)
+        document.body.appendChild(link)
+        link.click()
+        document.body.removeChild(link)
     }
 
     const getStatusIcon = (status: string) => {
@@ -408,17 +376,21 @@ const LiveClass = ({
                                                 onClick={handleDownloadAttendance}
                                                 disabled={
                                                     !canEdit ||
-                                                    !session?.s3link ||
-                                                    session?.s3link === 'not found'
+                                                    attendanceLoading ||
+                                                    !isAttendanceReady
                                                 }
                                             >
-                                                Download Attendance
+                                                {attendanceLoading
+                                                    ? 'Checking...'
+                                                    : 'Download Attendance'}
                                             </Button>
                                         </TooltipTrigger>
                                         <TooltipContent>
                                             <p className="text-sm">
-                                                {!session?.s3link || session?.s3link === 'not found' 
-                                                    ? 'No attendance report available' 
+                                                {attendanceLoading
+                                                    ? 'Checking attendance availability...'
+                                                    : !isAttendanceReady
+                                                    ? 'Attendance is not ready yet. Please check back later.'
                                                     : 'Click to download attendance report'}
                                             </p>
                                         </TooltipContent>

--- a/src/app/student/_pages/CourseDashboardPage.tsx
+++ b/src/app/student/_pages/CourseDashboardPage.tsx
@@ -18,7 +18,7 @@ import { useBootcampProgress } from '@/app/student/hooks/useBootcampProgress';
 import { useAllModulesForStudents } from '@/app/student/hooks/useAllModulesForStudents';
 import { useUpcomingEvents } from '@/app/student/hooks/useUpcomingEvents';
 import { UpcomingEvent, CompletedClass } from '@/hooks/hookType';
-import { useCompletedClasses } from '@/hooks/useCompletedClasses';
+import { useStudentCompletedClasses } from '@/app/student/hooks/useStudentCompletedClasses';
 import { useLatestUpdatedCourse } from '@/app/student/hooks/useLatestUpdatedCourse';
 import { useMentors } from '@/app/student/hooks/useMentors';
 import TruncatedDescription from "@/app/student/_components/TruncatedDescription";
@@ -56,7 +56,7 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
   const { progressData, loading: progressLoading, error: progressError } = useBootcampProgress(courseId);
   const { modules: apiModules, loading: modulesLoading, error: modulesError } = useAllModulesForStudents(courseId);
   const { upcomingEventsData, loading: eventsLoading, error: eventsError } = useUpcomingEvents(courseId);
-  const { completedClassesData, loading: classesLoading, error: classesError } = useCompletedClasses(courseId);
+  const { completedClassesData, loading: classesLoading, error: classesError } = useStudentCompletedClasses(courseId);
   const { latestCourseData, loading: latestCourseLoading, error: latestCourseError } = useLatestUpdatedCourse(courseId);
   const { mentors: mentorshipMentors } = useMentors('', Boolean(latestCourseData?.mentorshipEnabled), 1000, 0, orgId as string | undefined);
   // const { topEntries: leaderboardEntries, selfEntry: leaderboardSelfEntry, isSelfInTopFive, loading: leaderboardLoading, error: leaderboardError } = useLeaderboard(courseId);

--- a/src/app/student/hooks/hookTypes.ts
+++ b/src/app/student/hooks/hookTypes.ts
@@ -1102,3 +1102,38 @@ export interface UpdateLearnerProfilePayload {
     [key: string]: any
 }
 
+
+
+// useStudentCompletedClasses
+export interface StudentCompletedClass {
+  moduleId: any;
+  chapterId: any;
+  id: number;
+  title: string;
+  startTime: string;
+  endTime: string;
+  attendanceStatus: 'present' | 'absent';
+  duration: number;
+  s3Link: string;
+}
+
+export interface StudentAttendanceStats {
+  presentCount: number;
+  absentCount: number;
+  attendancePercentage: number;
+}
+
+export interface StudentCompletedClassesData {
+  batchId: number;
+  batchName: string;
+  classes: StudentCompletedClass[];
+  totalClasses: number;
+  totalPages: number;
+  attendanceStats: StudentAttendanceStats;
+}
+
+export interface UseStudentCompletedClassesReturn {
+  completedClassesData: StudentCompletedClassesData | null;
+  loading: boolean;
+  error: string | null;
+}

--- a/src/app/student/hooks/useStudentCompletedClasses.ts
+++ b/src/app/student/hooks/useStudentCompletedClasses.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+import { api } from '@/utils/axios.config';
+import {
+  StudentCompletedClassesData,
+  UseStudentCompletedClassesReturn,
+} from './hookTypes';
+
+export const useStudentCompletedClasses = (
+  bootcampId?: string | number
+): UseStudentCompletedClassesReturn => {
+  const [completedClassesData, setCompletedClassesData] =
+    useState<StudentCompletedClassesData | null>(null);
+  const [loading, setLoading] = useState(Boolean(bootcampId));
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!bootcampId) return;
+
+    const fetchCompletedClasses = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await api.get(
+          `/student/bootcamp/${bootcampId}/completed-classes/me`
+        );
+        // API returns { isSuccess, message, data: { batchId, classes, ... } }
+        setCompletedClassesData(response.data?.data ?? null);
+      } catch (err: any) {
+        setError(
+          err?.response?.data?.message || 'Failed to load completed classes'
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCompletedClasses();
+  }, [bootcampId]);
+
+  return { completedClassesData, loading, error };
+};
+
+export default useStudentCompletedClasses;


### PR DESCRIPTION
Admin Side

- Updated the Live Class Attendance download functionality to use the `/classes/attendance/{sessionId} `endpoint.
- Enabled/disabled the Download Attendance button based on attendanceStatus?.ready.
- Integrated attendance CSV download using the same endpoint.
- Created a reusable hook useAttendanceStatus under the admin hooks for attendance status and download handling.

Student Side

- Updated completed class details to use the new endpoint:
     ` /student/bootcamp/:bootcampId/completed-classes/me`
- Removed the need to pass userId since the endpoint uses the logged-in student's identity from the JWT.
- Fixed the incorrect attendance issue that some students were experiencing.