### PR TITLE
fix: use attendance status instead of recording link

### DIFF
--- a/src/app/student/_components/chapter-content/LiveClassContent.tsx
+++ b/src/app/student/_components/chapter-content/LiveClassContent.tsx
@@ -419,34 +419,30 @@ if (loading) {
                                         : 'TBD'}
                                 </p>
                             </div>
-                            {item.s3link && (
-                                <div className="text-left">
-                                    <p className="text-sm text-muted-foreground">
-                                        Your Attendance Duration{' '}
-                                    </p>
-                                    <p className="font-medium">
-                                        {item.duration} mins
-                                    </p>
-                                </div>
-                            )}
-                            {item.s3link && (
-                                <div className="text-left">
-                                    <p className="text-sm text-muted-foreground">
-                                        Attendance
-                                    </p>
-                                    <p
-                                        className={`font-medium ${
-                                            item.attendance === 'present'
-                                                ? 'text-success'
-                                                : 'text-destructive'
-                                        }`}
-                                    >
-                                        {item.attendance === 'present'
-                                            ? 'Present'
-                                            : 'Absent'}
-                                    </p>
-                                </div>
-                            )}
+                            <div className="text-left">
+                                <p className="text-sm text-muted-foreground">
+                                    Your Attendance Duration{' '}
+                                </p>
+                                <p className="font-medium">
+                                    {item.duration} mins
+                                </p>
+                            </div>
+                            <div className="text-left">
+                                <p className="text-sm text-muted-foreground">
+                                    Attendance
+                                </p>
+                                <p
+                                    className={`font-medium ${
+                                        item.attendance === 'present'
+                                            ? 'text-success'
+                                            : 'text-destructive'
+                                    }`}
+                                >
+                                    {item.attendance === 'present'
+                                        ? 'Present'
+                                        : 'Absent'}
+                                </p>
+                            </div>
                         </div>
                         <p className="text-success mb-2 flex items-center gap-2">
                             <Check className="w-5 h-5" />

--- a/src/app/student/_pages/CourseDashboardPage.tsx
+++ b/src/app/student/_pages/CourseDashboardPage.tsx
@@ -394,25 +394,14 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
                       <Badge
                         variant="outline"
                         className={
-                          classItem.s3Link === null ||
-                            classItem.s3Link ===
-                            'not found'
-                            ? 'text-warning border-warning'
-                            : classItem.s3Link &&
-                              classItem.attendanceStatus ===
-                              'absent'
-                              ? 'text-destructive border-destructive'
-                              : 'text-success border-success'
+                          classItem.attendanceStatus === 'absent'
+                            ? 'text-destructive border-destructive'
+                            : 'text-success border-success'
                         }
                       >
-                        {classItem.s3Link === null ||
-                          classItem.s3Link === 'not found'
-                          ? 'Processing'
-                          : classItem.s3Link &&
-                            classItem.attendanceStatus ===
-                            'absent'
-                            ? 'Absent'
-                            : 'Present'}
+                        {classItem.attendanceStatus === 'absent'
+                          ? 'Absent'
+                          : 'Present'}
                       </Badge>
                       <TooltipProvider>
                         <Tooltip>
@@ -549,25 +538,14 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
                       <Badge
                         variant="outline"
                         className={
-                          classItem.s3Link === null ||
-                            classItem.s3Link ===
-                            'not found'
-                            ? 'text-warning border-warning'
-                            : classItem.s3Link &&
-                              classItem.attendanceStatus ===
-                              'absent'
-                              ? 'text-destructive border-destructive'
-                              : 'text-success border-success'
+                          classItem.attendanceStatus === 'absent'
+                            ? 'text-destructive border-destructive'
+                            : 'text-success border-success'
                         }
                       >
-                        {classItem.s3Link === null ||
-                          classItem.s3Link === 'not found'
-                          ? 'Processing'
-                          : classItem.s3Link &&
-                            classItem.attendanceStatus ===
-                            'absent'
-                            ? 'Absent'
-                            : 'Present'}{' '}
+                        {classItem.attendanceStatus === 'absent'
+                          ? 'Absent'
+                          : 'Present'}{' '}
                       </Badge>
                       <TooltipProvider>
                         <Tooltip>
@@ -1510,28 +1488,14 @@ const CourseDashboard = ({ courseId }: { courseId: string }) => {
                                 <Badge
                                   variant="outline"
                                   className={
-                                    classItem.s3Link ===
-                                      null ||
-                                      classItem.s3Link ===
-                                      'not found'
-                                      ? 'text-warning border-warning'
-                                      : classItem.s3Link &&
-                                        classItem.attendanceStatus ===
-                                        'absent'
-                                        ? 'text-destructive border-destructive'
-                                        : 'text-success border-success'
+                                    classItem.attendanceStatus === 'absent'
+                                      ? 'text-destructive border-destructive'
+                                      : 'text-success border-success'
                                   }
                                 >
-                                  {classItem.s3Link ===
-                                    null ||
-                                    classItem.s3Link ===
-                                    'not found'
-                                    ? 'Processing'
-                                    : classItem.s3Link &&
-                                      classItem.attendanceStatus ===
-                                      'absent'
-                                      ? 'Absent'
-                                      : 'Present'}{' '}
+                                  {classItem.attendanceStatus === 'absent'
+                                    ? 'Absent'
+                                    : 'Present'}{' '}
                                 </Badge>
                                 <TooltipProvider>
                                   <Tooltip>

--- a/src/app/student/course/[courseId]/org/[orgId]/studentAssessment/_studentAssessmentComponents/IDE.tsx
+++ b/src/app/student/course/[courseId]/org/[orgId]/studentAssessment/_studentAssessmentComponents/IDE.tsx
@@ -8,7 +8,7 @@ import {
     ResizableHandle,
 } from '@/components/ui/resizable'
 import { ChevronLeft, Code, Lock, Play, Upload, CheckCircle, Sun, Moon } from 'lucide-react'
-import { useCodingSubmissionStore, useLazyLoadedStudentData, useThemeStore } from '@/store/store'
+import { useLazyLoadedStudentData, useThemeStore } from '@/store/store'
 import { api } from '@/utils/axios.config'
 import Editor from '@monaco-editor/react'
 import { ArrowLeft } from 'lucide-react'
@@ -63,7 +63,6 @@ const IDE: React.FC<IDEProps> = ({
     const [currentCode, setCurrentCode] = useState('')
     const [result, setResult] = useState('')
     const [codeError, setCodeError] = useState('')
-    const { codingSubmissionAction, setCodingSubmissionAction } = useCodingSubmissionStore()
 
     const editorLanguages = [
         { lang: 'java', id: 96 },
@@ -215,6 +214,17 @@ const IDE: React.FC<IDEProps> = ({
         }
     }, [runCodeLanguageId, runSourceCode])
 
+     useEffect(() => {
+        setIsSubmitted(false)
+        setIsDisabled(false)
+        setIsOpen(false)
+        setCodeError('')
+        setResult('')
+        setCurrentCode('')
+        setCodeResult(null)
+    }, [params.editor, setCodeResult])
+
+
     return (
         <div className="min-h-screen bg-gradient-to-br from-background via-primary-light/5 to-accent-light/10">
             {/* Header Bar with Navigation and Actions */}
@@ -290,7 +300,7 @@ const IDE: React.FC<IDEProps> = ({
                                     size="sm"
                                     variant="outline"
                                     className="text-black hover:text-black border-primary hover:border-primary hover:bg-primary/10 dark:text-white"
-                                    disabled={(loading || isSubmitted) || codingSubmissionAction === 'submit'}
+                                    disabled={(loading || isSubmitted)}
                                 >
                                     {loading ? <Spinner className="w-4 h-4" /> : <Play className="w-4 h-4" />}
                                     <span className="ml-2 font-medium">Run Code</span>
@@ -299,7 +309,7 @@ const IDE: React.FC<IDEProps> = ({
                                     onClick={(e) => handleSubmit(e, 'submit')}
                                     size="sm"
                                     className="bg-primary-dark hover:bg-primary text-primary-foreground"
-                                    disabled={(loading || isSubmitted) || codingSubmissionAction === 'submit'}
+                                    disabled={(loading || isSubmitted)}
                                 >
                                     {loading ? <Spinner className="w-4 h-4" /> : <Upload className="w-4 h-4" />}
                                     <span className="ml-2 font-medium">Submit Solution</span>


### PR DESCRIPTION
Student Assessment & Attendance Fixes

 Updated the Submit button logic in:
    src/app/student/course/[courseId]/org/[orgId]/studentAssessment/_studentAssessmentComponents/IDE.tsx
    
Fixed the Student Course attendance status to rely on the attendance status response instead of the S3 recording link.

Updated the Chapter attendance logic to use the attendance status response instead of checking the recording link.
