### PR TITLE
fix: add zod validation for graduation date based on year of study

### DIFF
--- a/src/app/student/_pages/EditProfilePage.tsx
+++ b/src/app/student/_pages/EditProfilePage.tsx
@@ -45,6 +45,11 @@ import {
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useOnboardingStorage } from '@/app/student/hooks/use-profile';
 import { SKILLS_BY_CATEGORY, MONTHS, getYearsArray } from '@/lib/profile.mockData';
+import { 
+  validateGraduationDate, 
+  getAllowedYears, 
+  getAllowedMonths
+} from '@/app/student/_utils/graduationDateValidation';
 import type {
   CompetitiveProfile,
   WorkExperience,
@@ -753,6 +758,17 @@ export const EditProfilePage: React.FC = () => {
     if (!String(updatedStep1.branch || '').trim()) {
       fieldErrors.push('Branch is required');
     }
+    
+    // Validate graduation date
+    const graduationValidation = validateGraduationDate(
+      updatedStep1.graduationDate, 
+      updatedStep1.yearOfStudy
+    );
+    
+    if (!graduationValidation.isValid) {
+      fieldErrors.push(graduationValidation.error || 'Invalid graduation date');
+    }
+    
     if (fieldErrors.length > 0) {
       showRequiredFieldErrors(fieldErrors);
       return;
@@ -2276,15 +2292,39 @@ export const EditProfilePage: React.FC = () => {
                                 <div className="mt-2">
                                   <Select
                                     value={editedData?.step1?.yearOfStudy ?? step1.yearOfStudy}
-                                    onValueChange={(value) =>
-                                      setEditedData((prev: any) => ({
-                                        ...prev,
-                                        step1: {
-                                          ...(prev.step1 || {}),
-                                          yearOfStudy: value,
-                                        },
-                                      }))
-                                    }
+                                    onValueChange={(value) => {
+                                      const currentYear = new Date().getFullYear().toString();
+                                      
+                                      setEditedData((prev: any) => {
+                                        const currentGradDate = prev.step1?.graduationDate ?? step1.graduationDate;
+                                        let newGradDate = currentGradDate;
+                                        
+                                        if (value !== 'passed_out') {
+                                          // For current students (1st, 2nd, 3rd, 4th), always auto-set current year
+                                          newGradDate = {
+                                            ...currentGradDate,
+                                            year: currentYear,
+                                          };
+                                        } else {
+                                          // For passout, validate existing date and clear if invalid
+                                          if (currentGradDate?.month && currentGradDate?.year) {
+                                            const validation = validateGraduationDate(currentGradDate, value);
+                                            if (!validation.isValid) {
+                                              newGradDate = { month: '', year: '' };
+                                            }
+                                          }
+                                        }
+                                        
+                                        return {
+                                          ...prev,
+                                          step1: {
+                                            ...(prev.step1 || {}),
+                                            yearOfStudy: value,
+                                            graduationDate: newGradDate,
+                                          },
+                                        };
+                                      });
+                                    }}
                                   >
                                     <SelectTrigger>
                                       <SelectValue placeholder="Select year of study" />
@@ -2311,7 +2351,10 @@ export const EditProfilePage: React.FC = () => {
                                 <div className="grid grid-cols-2 gap-4 mt-2">
                                   <Select
                                     value={editedData?.step1?.graduationDate?.month ?? step1.graduationDate.month}
-                                    onValueChange={(val) =>
+                                    onValueChange={(val) => {
+                                      const currentYearOfStudy = editedData?.step1?.yearOfStudy ?? step1.yearOfStudy;
+                                      const currentYear = editedData?.step1?.graduationDate?.year ?? step1.graduationDate.year;
+                                      
                                       setEditedData((prev: any) => ({
                                         ...prev,
                                         step1: {
@@ -2321,30 +2364,26 @@ export const EditProfilePage: React.FC = () => {
                                             month: val,
                                           },
                                         },
-                                      }))
-                                    }
+                                      }));
+                                    }}
                                   >
                                     <SelectTrigger className="bg-muted/30">
                                       <SelectValue placeholder="Month" />
                                     </SelectTrigger>
                                     <SelectContent>
-                                      <SelectItem value="January">January</SelectItem>
-                                      <SelectItem value="February">February</SelectItem>
-                                      <SelectItem value="March">March</SelectItem>
-                                      <SelectItem value="April">April</SelectItem>
-                                      <SelectItem value="May">May</SelectItem>
-                                      <SelectItem value="June">June</SelectItem>
-                                      <SelectItem value="July">July</SelectItem>
-                                      <SelectItem value="August">August</SelectItem>
-                                      <SelectItem value="September">September</SelectItem>
-                                      <SelectItem value="October">October</SelectItem>
-                                      <SelectItem value="November">November</SelectItem>
-                                      <SelectItem value="December">December</SelectItem>
+                                      {getAllowedMonths(
+                                        editedData?.step1?.yearOfStudy ?? step1.yearOfStudy,
+                                        editedData?.step1?.graduationDate?.year ?? step1.graduationDate.year
+                                      ).map((month) => (
+                                        <SelectItem key={month} value={month}>{month}</SelectItem>
+                                      ))}
                                     </SelectContent>
                                   </Select>
                                   <Select
                                     value={editedData?.step1?.graduationDate?.year ?? step1.graduationDate.year}
-                                    onValueChange={(val) =>
+                                    onValueChange={(val) => {
+                                      const currentYearOfStudy = editedData?.step1?.yearOfStudy ?? step1.yearOfStudy;
+                                      
                                       setEditedData((prev: any) => ({
                                         ...prev,
                                         step1: {
@@ -2352,16 +2391,20 @@ export const EditProfilePage: React.FC = () => {
                                           graduationDate: {
                                             ...(prev.step1?.graduationDate || step1.graduationDate),
                                             year: val,
+                                            // Clear month if it becomes invalid with new year
+                                            month: getAllowedMonths(currentYearOfStudy, val).includes(
+                                              prev.step1?.graduationDate?.month ?? step1.graduationDate.month
+                                            ) ? (prev.step1?.graduationDate?.month ?? step1.graduationDate.month) : '',
                                           },
                                         },
-                                      }))
-                                    }
+                                      }));
+                                    }}
                                   >
                                     <SelectTrigger className="bg-muted/30">
                                       <SelectValue placeholder="Year" />
                                     </SelectTrigger>
                                     <SelectContent>
-                                      {getYearsArray(1990).map((year) => (
+                                      {getAllowedYears(editedData?.step1?.yearOfStudy ?? step1.yearOfStudy).map((year) => (
                                         <SelectItem key={year} value={year}>{year}</SelectItem>
                                       ))}
                                     </SelectContent>

--- a/src/app/student/_utils/graduationDateValidation.ts
+++ b/src/app/student/_utils/graduationDateValidation.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+import { MONTHS } from '@/lib/profile.mockData';
+
+// Simple helper functions
+const getCurrentYear = () => new Date().getFullYear();
+const getCurrentMonth = () => new Date().getMonth() + 1; // 1-based
+const getMonthNumber = (monthName: string): number => MONTHS.indexOf(monthName) + 1;
+const isPassout = (yearOfStudy: string): boolean => yearOfStudy === 'passed_out';
+
+// Main validation function - simple and clear
+export const validateGraduationDate = (
+  graduationDate: { month: string; year: string },
+  yearOfStudy: string
+) => {
+  const currentYear = getCurrentYear();
+  const currentMonth = getCurrentMonth();
+  
+  // Check required fields first - priority over other validations
+  if (!graduationDate.month && !graduationDate.year) {
+    return { isValid: false, error: 'Graduation month and year are required' };
+  }
+  if (!graduationDate.month) {
+    return { isValid: false, error: 'Graduation month is required' };
+  }
+  if (!graduationDate.year) {
+    return { isValid: false, error: 'Graduation year is required' };
+  }
+  
+  const selectedYear = Number(graduationDate.year);
+  const selectedMonth = getMonthNumber(graduationDate.month);
+  
+  if (isPassout(yearOfStudy)) {
+    // Passout: 1990 to current year, current year only up to current month
+    if (selectedYear < 1990) {
+      return { isValid: false, error: 'Graduation year cannot be before 1990' };
+    }
+    if (selectedYear > currentYear) {
+      return { isValid: false, error: 'Future graduation dates are not allowed' };
+    }
+    if (selectedYear === currentYear && selectedMonth > currentMonth) {
+      return { isValid: false, error: `For ${currentYear}, only months up to ${MONTHS[currentMonth - 1]} are allowed` };
+    }
+  } else {
+    // Current students: only current year
+    if (selectedYear !== currentYear) {
+      return { isValid: false, error: `For ${yearOfStudy} year students, only ${currentYear} is allowed` };
+    }
+  }
+  
+  return { isValid: true, error: null };
+};
+
+// Get allowed years for dropdown
+export const getAllowedYears = (yearOfStudy: string): string[] => {
+  const currentYear = getCurrentYear();
+  
+  if (isPassout(yearOfStudy)) {
+    const years = [];
+    for (let year = currentYear; year >= 1990; year--) {
+      years.push(year.toString());
+    }
+    return years;
+  } else {
+    return [currentYear.toString()];
+  }
+};
+
+// Get allowed months for dropdown
+export const getAllowedMonths = (yearOfStudy: string, selectedYear: string): string[] => {
+  const currentYear = getCurrentYear();
+  const currentMonth = getCurrentMonth();
+  const selectedYearNum = Number(selectedYear);
+  
+  if (isPassout(yearOfStudy) && selectedYearNum === currentYear) {
+    return MONTHS.slice(0, currentMonth);
+  } else {
+    return [...MONTHS];
+  }
+};

--- a/src/app/student/profile/ProfileStep1.tsx
+++ b/src/app/student/profile/ProfileStep1.tsx
@@ -18,6 +18,11 @@ import { useLearnerBranchDetails } from '@/app/student/hooks/useLearnerBranchDet
 import { useCollegeSearch } from '@/app/student/hooks/useCollegeSearch';
 import { getUser } from '@/store/store';
 import { toast } from '@/components/ui/use-toast';
+import { 
+  validateGraduationDate, 
+  getAllowedYears, 
+  getAllowedMonths
+} from '@/app/student/_utils/graduationDateValidation';
 
 interface ProfileStep1Props {
   initialData?: Partial<Step1Type>;
@@ -127,7 +132,8 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
   const { degreeDetails, loading: isDegreeLoading } = useLearnerDegreeDetails();
   const { loading: isBranchLoading, getBranchesForDegree } = useLearnerBranchDetails();
   
-  const years = getYearsArray(1990);
+  const years = getAllowedYears(formData.yearOfStudy);
+  const allowedMonths = getAllowedMonths(formData.yearOfStudy, selectedYear);
   const degreeOptions = degreeDetails.map((item) => item.name);
   const selectedDegreeDetails = useMemo(
     () =>
@@ -421,6 +427,16 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
     };
   }, [showGraduationDatePicker]);
 
+  // Sync selectedYear and selectedMonth with formData when they change
+  useEffect(() => {
+    if (formData.graduationDate.year !== selectedYear) {
+      setSelectedYear(formData.graduationDate.year);
+    }
+    if (formData.graduationDate.month !== selectedMonth) {
+      setSelectedMonth(formData.graduationDate.month);
+    }
+  }, [formData.graduationDate.year, formData.graduationDate.month, selectedYear, selectedMonth]);
+
   // Validate phone number
   const validatePhoneNumber = (phone: string): boolean => {
     const phoneRegex = /^(\+91)?[6-9]\d{9}$/;
@@ -463,12 +479,10 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
       newErrors.branch = 'Branch selection is required';
     }
 
-    if (!data.graduationDate.month && !data.graduationDate.year) {
-      newErrors.graduationDate = 'Graduation month and year are required';
-    } else if (!data.graduationDate.month) {
-      newErrors.graduationDate = 'Graduation month is required';
-    } else if (!data.graduationDate.year) {
-      newErrors.graduationDate = 'Graduation year is required';
+    // Validate graduation date
+    const graduationValidation = validateGraduationDate(data.graduationDate, data.yearOfStudy);
+    if (!graduationValidation.isValid) {
+      newErrors.graduationDate = graduationValidation.error || 'Invalid graduation date';
     }
 
     setErrors(newErrors);
@@ -622,6 +636,49 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
           return next;
         });
       }
+    } else if (name === 'yearOfStudy') {
+      const currentYear = new Date().getFullYear().toString();
+      
+      if (value !== 'passed_out') {
+        // For current students (1st, 2nd, 3rd, 4th), always auto-set current year
+        setSelectedYear(currentYear);
+        setFormData((prev) => ({
+          ...prev,
+          yearOfStudy: value as Step1Type['yearOfStudy'],
+          graduationDate: {
+            ...prev.graduationDate,
+            year: currentYear,
+          },
+        }));
+        
+        // Clear any graduation date errors since we're auto-selecting valid year
+        if (errors.graduationDate) {
+          setErrors((prev) => {
+            const next = { ...prev };
+            delete next.graduationDate;
+            return next;
+          });
+        }
+      } else {
+        // For passout, validate existing date and clear if invalid
+        const currentGradDate = formData.graduationDate;
+        let newGradDate = currentGradDate;
+        
+        if (currentGradDate.month && currentGradDate.year) {
+          const validation = validateGraduationDate(currentGradDate, value);
+          if (!validation.isValid) {
+            setSelectedMonth('');
+            setSelectedYear('');
+            newGradDate = { month: '', year: '' };
+          }
+        }
+        
+        setFormData((prev) => ({
+          ...prev,
+          yearOfStudy: value as Step1Type['yearOfStudy'],
+          graduationDate: newGradDate,
+        }));
+      }
     } else if (name === 'graduationMonth' || name === 'graduationYear') {
       setFormData((prev) => ({
         ...prev,
@@ -670,6 +727,20 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
 
   const handleGraduationDateSave = () => {
     if (selectedMonth && selectedYear) {
+      // Validate the selected graduation date
+      const validation = validateGraduationDate(
+        { month: selectedMonth, year: selectedYear }, 
+        formData.yearOfStudy
+      );
+      
+      if (!validation.isValid) {
+        setErrors((prev) => ({
+          ...prev,
+          graduationDate: validation.error || 'Invalid graduation date',
+        }));
+        return;
+      }
+      
       setFormData((prev) => ({
         ...prev,
         graduationDate: {
@@ -677,6 +748,7 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
           year: selectedYear,
         },
       }));
+      
       // Clear error if exists
       if (errors.graduationDate) {
         setErrors((prev) => {
@@ -1252,8 +1324,13 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
                   </Label>
                   <div className="grid grid-cols-2 gap-4">
                     <Select
-                      value={formData.graduationDate.month}
+                      key={`month-${formData.yearOfStudy}`}
+                      value={formData.graduationDate.month || selectedMonth}
                       onValueChange={(value) => {
+                        // Validate the new month selection
+                        const newGradDate = { ...formData.graduationDate, month: value };
+                        const validation = validateGraduationDate(newGradDate, formData.yearOfStudy);
+                        
                         setFormData((prev) => ({
                           ...prev,
                           graduationDate: {
@@ -1261,7 +1338,13 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
                             month: value,
                           },
                         }));
-                        if (errors.graduationDate) {
+                        
+                        if (!validation.isValid) {
+                          setErrors((prev) => ({
+                            ...prev,
+                            graduationDate: validation.error || 'Invalid graduation date',
+                          }));
+                        } else if (errors.graduationDate) {
                           setErrors((prev) => {
                             const next = { ...prev };
                             delete next.graduationDate;
@@ -1274,7 +1357,7 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
                         <SelectValue placeholder="Month" />
                       </SelectTrigger>
                       <SelectContent>
-                        {MONTHS.map((month) => (
+                        {allowedMonths.map((month) => (
                           <SelectItem key={month} value={month}>
                             {month}
                           </SelectItem>
@@ -1283,8 +1366,13 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
                     </Select>
                     
                     <Select
-                      value={formData.graduationDate.year}
+                      key={`year-${formData.yearOfStudy}`}
+                      value={formData.graduationDate.year || selectedYear}
                       onValueChange={(value) => {
+                        // Validate the new year selection
+                        const newGradDate = { ...formData.graduationDate, year: value };
+                        const validation = validateGraduationDate(newGradDate, formData.yearOfStudy);
+                        
                         setFormData((prev) => ({
                           ...prev,
                           graduationDate: {
@@ -1292,7 +1380,27 @@ export const ProfileStep1Component: React.FC<ProfileStep1Props> = ({
                             year: value,
                           },
                         }));
-                        if (errors.graduationDate) {
+                        
+                        // Clear month if it becomes invalid with new year
+                        if (formData.graduationDate.month) {
+                          const newAllowedMonths = getAllowedMonths(formData.yearOfStudy, value);
+                          if (!newAllowedMonths.includes(formData.graduationDate.month)) {
+                            setFormData((prev) => ({
+                              ...prev,
+                              graduationDate: {
+                                ...prev.graduationDate,
+                                month: '',
+                              },
+                            }));
+                          }
+                        }
+                        
+                        if (!validation.isValid && newGradDate.month) {
+                          setErrors((prev) => ({
+                            ...prev,
+                            graduationDate: validation.error || 'Invalid graduation date',
+                          }));
+                        } else if (errors.graduationDate) {
                           setErrors((prev) => {
                             const next = { ...prev };
                             delete next.graduationDate;


### PR DESCRIPTION
Student Profile: Graduation Date Validation

Changes
   Added "Graduation Date validation using Zod"based on the selected "Year of Study".
   For "1st, 2nd, 3rd, and 4th Year" students:
       Graduation Date can only be selected from the "current year".
       Future years are not allowed.
       
  or "Passout" students:
     Graduation Date can be selected from *"1990 up to the current year".
     Future months and future years are not allowed.
     Added validation error messages for invalid Graduation Dates.
    Prevents form submission when the selected Graduation Date does not meet the validation rules.
